### PR TITLE
Again fixes for latin belarusian strings.

### DIFF
--- a/locales/by_lat.strings
+++ b/locales/by_lat.strings
@@ -430,11 +430,3 @@
 
 "no_data" = "Niama dadzienych";
 "no_data_description" = "U hetym pradstaŭleńni adsutniczajuć dadzienyja.";
-
-%{ Additional fixes %}
-
-"time_today" = "Siońnia"
-"time_at_sp" = "a"
-"points" = "Hałasy"
-"on_your_account" = "na vašym rachunku"
-"points_count" = "hałasoŭ"


### PR DESCRIPTION
I'd like to apologize. Looks like that it doesn't work properly without doing additional tasks in order to make other languages look like russian. (@time_at_sp, etc.)
Sorry for bothering you with my pulls.