### PR TITLE
Add group creator display options

### DIFF
--- a/Web/Models/Entities/Club.php
+++ b/Web/Models/Entities/Club.php
@@ -109,6 +109,11 @@ class Club extends RowModel
     {
         return $this->getRecord()->closed;
     }
+
+    function getAdministratorsListDisplay(): int
+    {
+        return $this->getRecord()->administrators_list_display;
+    }
     
     function getType(): int
     {

--- a/Web/Presenters/GroupPresenter.php
+++ b/Web/Presenters/GroupPresenter.php
@@ -150,6 +150,7 @@ final class GroupPresenter extends OpenVKPresenter
             $club->setAbout(empty($this->postParam("about")) ? NULL : $this->postParam("about"));
             $club->setShortcode(empty($this->postParam("shortcode")) ? NULL : $this->postParam("shortcode"));
 	        $club->setWall(empty($this->postParam("wall")) ? 0 : 1);
+            $club->setAdministrators_List_Display(empty($this->postParam("administrators_list_display")) ? 0 : $this->postParam("administrators_list_display"));
             
             if($_FILES["ava"]["error"] === UPLOAD_ERR_OK) {
                 $photo = new Photo;

--- a/Web/Presenters/templates/Group/Edit.xml
+++ b/Web/Presenters/templates/Group/Edit.xml
@@ -69,6 +69,16 @@
                             <input type="checkbox" name="wall" value="1" {if $club->canPost()}checked{/if}/> {_group_allow_post_for_everyone}
                         </td>
                     </tr>
+                    <tr>
+                        <td width="120" valign="top">
+                            <span class="nobold">{_group_administrators_list}: </span>
+                        </td>
+                        <td>
+                            <input type="radio" name="administrators_list_display" value="0" {if $club->getAdministratorsListDisplay() == 0}checked{/if}/> {_group_display_only_creator}<br>
+                            <input type="radio" name="administrators_list_display" value="1" {if $club->getAdministratorsListDisplay() == 1}checked{/if}/> {_group_display_all_administrators}<br>
+                            <input type="radio" name="administrators_list_display" value="2" {if $club->getAdministratorsListDisplay() == 2}checked{/if}/> {_group_dont_display_administrators_list}<br>
+                        </td>
+                    </tr>
 
                     <tr>
                         <td>

--- a/Web/Presenters/templates/Group/View.xml
+++ b/Web/Presenters/templates/Group/View.xml
@@ -105,44 +105,39 @@
             {_"group_type_open"}
         </div>
     </div>
-    {if $club->getAdministratorsListDisplay() == 0}
-        <div>
-            <div class="content_title_expanded" onclick="hidePanel(this);">
-                {_"creator"}
-            </div>
-            <div style="padding:4px">
-                {var author = $club->getOwner()}
-                <ul>
-                    <li>
-                        <a href="{$author->getURL()}"><b>{$author->getCanonicalName()}</b></a>
-                    </li>
-                </ul>
-            </div>
+    <div n:if="$club->getAdministratorsListDisplay() == 0">
+        <div class="content_title_expanded" onclick="hidePanel(this);">
+            {_"creator"}
         </div>
-    {elseif $club->getAdministratorsListDisplay() == 1}
-        <div>
-            <div class="content_title_expanded" onclick="hidePanel(this);">
-                {_"administrators"}
-            </div>
-            <div style="padding:4px">
-                {var author = $club->getOwner()}
-                <ul>
-                    <li>
-                        <a href="{$author->getURL()}"><b>{$author->getCanonicalName()}</b></a>
-                    </li>
-                    <li n:foreach="$club->getManagers(1) as $manager">
-                        <a href="{$manager->getURL()}"><b>{$manager->getCanonicalName()}</b></a>
-                    </li>
-                    {var managersCount = $club->getManagersCount()}
-                    {if $managersCount > 7}
-                        <li>
-                            <b>{tr("and_more", $managersCount - 7)}</b>
-                        </li>
-                    {/if}
-                </ul>
-            </div>
+        <div style="padding:4px">
+            {var author = $club->getOwner()}
+            <ul>
+                <li>
+                    <a href="{$author->getURL()}"><b>{$author->getCanonicalName()}</b></a>
+                </li>
+            </ul>
         </div>
-    {/if}
+    </div>
+    <div n:if="$club->getAdministratorsListDisplay() == 1">
+        <div class="content_title_expanded" onclick="hidePanel(this);">
+            {_"administrators"}
+        </div>
+        <div style="padding:4px">
+            {var author = $club->getOwner()}
+            <ul>
+                <li>
+                    <a href="{$author->getURL()}"><b>{$author->getCanonicalName()}</b></a>
+                </li>
+                <li n:foreach="$club->getManagers(1) as $manager">
+                    <a href="{$manager->getURL()}"><b>{$manager->getCanonicalName()}</b></a>
+                </li>
+                {var managersCount = $club->getManagersCount()}
+                <li n:if="$managersCount > 7">
+                    <b>{tr("and_more", $managersCount - 7)}</b>
+                </li>
+            </ul>
+        </div>
+    </div>
     <div n:if="$albumsCount > 0">
         <div class="content_title_expanded" onclick="hidePanel(this, {$albumsCount});">
             {_"albums"}

--- a/Web/Presenters/templates/Group/View.xml
+++ b/Web/Presenters/templates/Group/View.xml
@@ -105,19 +105,44 @@
             {_"group_type_open"}
         </div>
     </div>
-    <div>
-        <div class="content_title_expanded" onclick="hidePanel(this);">
-            {_"creator"}
+    {if $club->getAdministratorsListDisplay() == 0}
+        <div>
+            <div class="content_title_expanded" onclick="hidePanel(this);">
+                {_"creator"}
+            </div>
+            <div style="padding:4px">
+                {var author = $club->getOwner()}
+                <ul>
+                    <li>
+                        <a href="{$author->getURL()}"><b>{$author->getCanonicalName()}</b></a>
+                    </li>
+                </ul>
+            </div>
         </div>
-        <div style="padding:4px">
-            {var author = $club->getOwner()}
-            <ul>
-                <li>
-                    <a href="{$author->getURL()}"><b>{$author->getCanonicalName()}</b></a>
-                </li>
-            </ul>
+    {elseif $club->getAdministratorsListDisplay() == 1}
+        <div>
+            <div class="content_title_expanded" onclick="hidePanel(this);">
+                {_"administrators"}
+            </div>
+            <div style="padding:4px">
+                {var author = $club->getOwner()}
+                <ul>
+                    <li>
+                        <a href="{$author->getURL()}"><b>{$author->getCanonicalName()}</b></a>
+                    </li>
+                    <li n:foreach="$club->getManagers(1) as $manager">
+                        <a href="{$manager->getURL()}"><b>{$manager->getCanonicalName()}</b></a>
+                    </li>
+                    {var managersCount = $club->getManagersCount()}
+                    {if $managersCount > 7}
+                        <li>
+                            <b>{tr("and_more", $managersCount - 7)}</b>
+                        </li>
+                    {/if}
+                </ul>
+            </div>
         </div>
-    </div>
+    {/if}
     <div n:if="$albumsCount > 0">
         <div class="content_title_expanded" onclick="hidePanel(this, {$albumsCount});">
             {_"albums"}

--- a/install/sqls/00005-administrators-list.sql
+++ b/install/sqls/00005-administrators-list.sql
@@ -1,0 +1,1 @@
+ALTER TABLE groups ADD COLUMN administrators_list_display TINYINT(3) UNSIGNED NOT NULL DEFAULT 0;


### PR DESCRIPTION
# Summary
This PR adds two new views (and leaves the original) display of the group's author. This functionality was not in the original VK, but it doesn't matter :smile:

# Displays
## Display only group creator
Standard display as before. Used by default. Only the creator of the group is displayed
![Screenshot_20211105_115432](https://user-images.githubusercontent.com/50026114/140494987-d515732f-c192-44e4-96c6-7d1f9fdc787c.png)
## Display all administrators
Displays a list of administrators
![Screenshot_20211105_121113](https://user-images.githubusercontent.com/50026114/140495100-97309958-69c1-422a-9f75-5c899a32ef6f.png)
If there are more than 7 administrators, the rest will be hidden in this way
![Screenshot_20211105_114931](https://user-images.githubusercontent.com/50026114/140495153-22b7f622-4cae-4e9e-8e71-0b4512787c23.png)
## Display nothing
Neither the author of the group nor the list of administrators is displayed. I think the screenshot is not needed here

# Settings
All this is controlled from the group change page
![Screenshot_20211105_115109](https://user-images.githubusercontent.com/50026114/140495532-84af98ab-ef04-412e-8c1f-e9ec0db451d2.png)
The radio buttons are standard because I don't know how they were implemented in the original old VK

# Locales
openvk/locales#13
