### PR TITLE
When you like a repost, put likes on the entire hierarchy of repost posts recursively

### DIFF
--- a/Web/Models/Entities/Postable.php
+++ b/Web/Models/Entities/Postable.php
@@ -96,17 +96,35 @@ abstract class Postable extends Attachable
             yield (new Users)->get($like->origin);
     }
     
-    function toggleLike(User $user): void
+    function toggleLike(User $user): bool
     {
         $searchData = [
             "origin" => $user->getId(),
             "model"  => static::class,
             "target" => $this->getRecord()->id,
         ];
-        if(sizeof(DB::i()->getContext()->table("likes")->where($searchData)) > 0)
+
+        if(sizeof(DB::i()->getContext()->table("likes")->where($searchData)) > 0) {
             DB::i()->getContext()->table("likes")->where($searchData)->delete();
-        else
+            return false;
+        }
+
+        DB::i()->getContext()->table("likes")->insert($searchData);
+        return true;
+    }
+
+    function setLike(bool $liked, User $user): void
+    {
+        $searchData = [
+            "origin" => $user->getId(),
+            "model"  => static::class,
+            "target" => $this->getRecord()->id,
+        ];
+
+        if($liked)
             DB::i()->getContext()->table("likes")->insert($searchData);
+        else
+            DB::i()->getContext()->table("likes")->where($searchData)->delete();
     }
     
     function hasLikeFrom(User $user): bool

--- a/Web/Presenters/WallPresenter.php
+++ b/Web/Presenters/WallPresenter.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 namespace openvk\Web\Presenters;
 use openvk\Web\Models\Entities\{Post, Photo, Video, Club, User};
-use openvk\Web\Models\Entities\Notifications\{LikeNotification, RepostNotification, WallPostNotification};
+use openvk\Web\Models\Entities\Notifications\{RepostNotification, WallPostNotification};
 use openvk\Web\Models\Repositories\{Posts, Users, Clubs, Albums};
 use Chandler\Database\DatabaseConnection;
 use Nette\InvalidStateException as ISE;
@@ -278,9 +278,6 @@ final class WallPresenter extends OpenVKPresenter
         
         if(!is_null($this->user)) {
             $post->toggleLike($this->user->identity);
-            
-            if($post->getOwner(false)->getId() !== $this->user->identity->getId() && !($post->getOwner() instanceof Club))
-                (new LikeNotification($post->getOwner(false), $post, $this->user->identity))->emit();
         }
         
         $this->redirect(

--- a/quirks.yml
+++ b/quirks.yml
@@ -34,3 +34,13 @@ blobs.erase-upon-deletion: 0
 # + Set this option to 1 if you want to use quirky VK Mobile behaviour (yes graffiti in comments)
 # + Set this option to 0 if you want to use VK Desktop behaviour (no graffiti in comments)
 comments.allow-graffiti: 0
+
+# Maximum recursion depth of likes on reposts
+# Restriction on the recursion depth of repost likes.
+# For example, if the value is 5, likes will be set for a maximum of 5 posts, even if there are more posts in the repost hierarchy.
+# Needed to protect against attacks
+# 
+# Possible values:
+# + Set this option to -1 if you want to disable the limit
+# + Set this option to any non-negative number to be this limit
+wall.repost-liking-recursion-limit: 10


### PR DESCRIPTION
If you like a repost, all posts from the hierarchy will be liked. If you remove a like from a post, likes will be removed from all posts from the hierarchy. I don’t know what the load will be in the case of large hierarchies (for example, 20 posts), but with small hierarchies (5 posts) everything works fine. Fixes #159