### PR TITLE
OpenVK Modern: quick fix for page wrap

### DIFF
--- a/themepacks/openvk_modern/stylesheet.css
+++ b/themepacks/openvk_modern/stylesheet.css
@@ -107,6 +107,12 @@ body {
     border-bottom: solid 1px #EEE5B8;
 }
 
+.page-wrap {
+    border-bottom: solid 1px #fff;
+    border-left: solid 1px #fff;
+    border-right: solid 1px #fff;
+}
+
 .page_wrap {
     border-bottom: solid 1px #fff;
     border-left: solid 1px #fff;


### PR DESCRIPTION
зачем нам .page-wrap и .page_wrap когда эти классы имеют одни и те же свойства
дебилизм
но всё же теперь должно работать