### PR TITLE
Shut up notification listener on false triggers

### DIFF
--- a/Web/static/js/al_notifs.js
+++ b/Web/static/js/al_notifs.js
@@ -16,7 +16,7 @@ async function setupNotificationListener() {
         } catch(rejection) {
             if(rejection.message !== "Nothing to report") {
                 console.error(rejection);
-                break;
+                return;
             }
             
             console.info("No new notifications discovered... Redialing event broker");


### PR DESCRIPTION
За-йо-бал трещать ложными уведомлениями. Использует подкостыль из [комментария](https://github.com/openvk/openvk/issues/694#issuecomment-1229165601).

Markdown — гори там же.