### PR TITLE
Расстояние между комментами и инфой.

### DIFF
--- a/Web/Presenters/templates/Videos/View.xml
+++ b/Web/Presenters/templates/Videos/View.xml
@@ -27,7 +27,7 @@
     <hr/>
     
     <div style="width: 100%; min-height: 100px;">
-        <div style="float: left; min-height: 100px; width: 70%;">
+        <div style="float: left; min-height: 100px; width: 68%; margin-right: 2%;">
             {include "../components/comments.xml",
                      comments => $comments,
                      count => $cCount,


### PR DESCRIPTION
Этот коммит добавляет небольшое расстояние между блоком с Комментариями и Информацией (под видео). Так смотрится в разы лучше!
было:
![image](https://user-images.githubusercontent.com/85897688/203148666-614a12b5-f2ea-4698-b9fe-265b2739ccee.png)
стало:
![image](https://user-images.githubusercontent.com/85897688/203148695-0f3da6b5-ecea-4508-a91c-a441f7e598ab.png)
