### PR TITLE
Разные class для floating_sidebar

### DIFF
--- a/Web/Presenters/templates/@layout.xml
+++ b/Web/Presenters/templates/@layout.xml
@@ -163,7 +163,7 @@
                             </a>
 
                             <div class="floating_sidebar">
-                                <a class="minilink" href="/friends{$thisUser->getId()}">
+                                <a class="minilink-friends" href="/friends{$thisUser->getId()}">
                                     <object type="internal/link" n:if="$thisUser->getFollowersCount() > 0">
                                         <div class="counter">
                                             +{$thisUser->getFollowersCount()}
@@ -171,10 +171,10 @@
                                     </object>
                                     <img src="/assets/packages/static/openvk/img/friends.svg">
                                 </a>
-                                <a class="minilink" href="/albums{$thisUser->getId()}">
+                                <a class="minilink-albums" href="/albums{$thisUser->getId()}">
                                     <img src="/assets/packages/static/openvk/img/photos.svg">
                                 </a>
-                                <a class="minilink" href="/im">
+                                <a class="minilink-messenger" href="/im">
                                     <object type="internal/link" n:if="$thisUser->getUnreadMessagesCount() > 0">
                                         <div class="counter">
                                             +{$thisUser->getUnreadMessagesCount()}
@@ -182,10 +182,10 @@
                                     </object>
                                     <img src="/assets/packages/static/openvk/img/messages.svg">
                                 </a>
-                                <a class="minilink" href="/groups{$thisUser->getId()}">
+                                <a class="minilink-groups" href="/groups{$thisUser->getId()}">
                                     <img src="/assets/packages/static/openvk/img/groups.svg">
                                 </a>
-                                <a class="minilink" href="/notifications">
+                                <a class="minilink-notifications" href="/notifications">
                                     <object type="internal/link" n:if="$thisUser->getNotificationsCount() > 0">
                                         <div class="counter">
                                             +{$thisUser->getNotificationsCount()}

--- a/Web/Presenters/templates/@layout.xml
+++ b/Web/Presenters/templates/@layout.xml
@@ -182,7 +182,7 @@
                                     </object>
                                     <img src="/assets/packages/static/openvk/img/messages.svg">
                                 </a>
-                                <a id="minilink-groups" class="minilink"  href="/groups{$thisUser->getId()}">
+                                <a id="minilink-groups" class="minilink" href="/groups{$thisUser->getId()}">
                                     <img src="/assets/packages/static/openvk/img/groups.svg">
                                 </a>
                                 <a id="minilink-notifications" class="minilink" href="/notifications">

--- a/Web/Presenters/templates/@layout.xml
+++ b/Web/Presenters/templates/@layout.xml
@@ -163,7 +163,7 @@
                             </a>
 
                             <div class="floating_sidebar">
-                                <a class="minilink minilink-friends" href="/friends{$thisUser->getId()}">
+                                <a id="minilink-friends" class="minilink" href="/friends{$thisUser->getId()}">
                                     <object type="internal/link" n:if="$thisUser->getFollowersCount() > 0">
                                         <div class="counter">
                                             +{$thisUser->getFollowersCount()}

--- a/Web/Presenters/templates/@layout.xml
+++ b/Web/Presenters/templates/@layout.xml
@@ -171,10 +171,10 @@
                                     </object>
                                     <img src="/assets/packages/static/openvk/img/friends.svg">
                                 </a>
-                                <a class="minilink minilink-albums" href="/albums{$thisUser->getId()}">
+                                <a id="minilink-albums" class="minilink" href="/albums{$thisUser->getId()}">
                                     <img src="/assets/packages/static/openvk/img/photos.svg">
                                 </a>
-                                <a class="minilink minilink-messenger" href="/im">
+                                <a id="minilink-messenger" class="minilink" href="/im">
                                     <object type="internal/link" n:if="$thisUser->getUnreadMessagesCount() > 0">
                                         <div class="counter">
                                             +{$thisUser->getUnreadMessagesCount()}
@@ -182,10 +182,10 @@
                                     </object>
                                     <img src="/assets/packages/static/openvk/img/messages.svg">
                                 </a>
-                                <a class="minilink minilink-groups" href="/groups{$thisUser->getId()}">
+                                <a id="minilink-groups" class="minilink"  href="/groups{$thisUser->getId()}">
                                     <img src="/assets/packages/static/openvk/img/groups.svg">
                                 </a>
-                                <a class="minilink minilink-notifications" href="/notifications">
+                                <a id="minilink-notifications" class="minilink" href="/notifications">
                                     <object type="internal/link" n:if="$thisUser->getNotificationsCount() > 0">
                                         <div class="counter">
                                             +{$thisUser->getNotificationsCount()}

--- a/Web/Presenters/templates/@layout.xml
+++ b/Web/Presenters/templates/@layout.xml
@@ -163,7 +163,7 @@
                             </a>
 
                             <div class="floating_sidebar">
-                                <a class="minilink-friends" href="/friends{$thisUser->getId()}">
+                                <a class="minilink minilink-friends" href="/friends{$thisUser->getId()}">
                                     <object type="internal/link" n:if="$thisUser->getFollowersCount() > 0">
                                         <div class="counter">
                                             +{$thisUser->getFollowersCount()}

--- a/Web/Presenters/templates/@layout.xml
+++ b/Web/Presenters/templates/@layout.xml
@@ -171,10 +171,10 @@
                                     </object>
                                     <img src="/assets/packages/static/openvk/img/friends.svg">
                                 </a>
-                                <a class="minilink-albums" href="/albums{$thisUser->getId()}">
+                                <a class="minilink minilink-albums" href="/albums{$thisUser->getId()}">
                                     <img src="/assets/packages/static/openvk/img/photos.svg">
                                 </a>
-                                <a class="minilink-messenger" href="/im">
+                                <a class="minilink minilink-messenger" href="/im">
                                     <object type="internal/link" n:if="$thisUser->getUnreadMessagesCount() > 0">
                                         <div class="counter">
                                             +{$thisUser->getUnreadMessagesCount()}
@@ -182,10 +182,10 @@
                                     </object>
                                     <img src="/assets/packages/static/openvk/img/messages.svg">
                                 </a>
-                                <a class="minilink-groups" href="/groups{$thisUser->getId()}">
+                                <a class="minilink minilink-groups" href="/groups{$thisUser->getId()}">
                                     <img src="/assets/packages/static/openvk/img/groups.svg">
                                 </a>
-                                <a class="minilink-notifications" href="/notifications">
+                                <a class="minilink minilink-notifications" href="/notifications">
                                     <object type="internal/link" n:if="$thisUser->getNotificationsCount() > 0">
                                         <div class="counter">
                                             +{$thisUser->getNotificationsCount()}


### PR DESCRIPTION
Если хочется при создании темы заменить иконки у уменьшенного сайд-бара то это сделать не выйдет. Данный фикс называет классы иконок по разному, чтобы можно было поменять каждую.

(не выйдет:)
![image](https://user-images.githubusercontent.com/85897688/203151643-29089250-7b0b-4574-babc-8d930037a779.png)
