### PR TITLE
Fix typo in Groups.getByID

### DIFF
--- a/VKAPI/Handlers/Groups.php
+++ b/VKAPI/Handlers/Groups.php
@@ -185,7 +185,7 @@ final class Groups extends VKAPIRequestHandler
 			                $response[$i]->site = $clb->getWebsite();
 			                break;
                         case "description":
-			                $response[$i]->desctiption = $clb->getDescription();
+			                $response[$i]->description = $clb->getDescription();
                             break;
 			            case "contacts":
                             $contacts;


### PR DESCRIPTION
Там допущена опечатка в слове `description` в методе `Groups.getByID`.