### PR TITLE
VKAPI: Re-add Utils.resolveScreenName

### DIFF
--- a/VKAPI/Handlers/Utils.php
+++ b/VKAPI/Handlers/Utils.php
@@ -1,10 +1,46 @@
 <?php declare(strict_types=1);
 namespace openvk\VKAPI\Handlers;
+use openvk\Web\Models\Repositories\{Users, Clubs};
 
 final class Utils extends VKAPIRequestHandler
 {
     function getServerTime(): int
     {
         return time();
+    }
+
+    function resolveScreenName(string $screen_name): object
+    {
+        if(\Chandler\MVC\Routing\Router::i()->getMatchingRoute("/$screen_name")[0]->presenter !== "UnknownTextRouteStrategy") {
+            if(substr($screen_name, 0, strlen("id")) === "id") {
+                return (object) [
+                    "object_id" => (int) substr($screen_name, strlen("id")),
+                    "type"      => "user"
+                ];
+            } else if(substr($screen_name, 0, strlen("club")) === "club") {
+                return (object) [
+                    "object_id" => (int) substr($screen_name, strlen("club")),
+                    "type"      => "group"
+                ];
+            }
+        } else {
+            $user = (new Users)->getByShortURL($screen_name);
+            if($user) {
+                return (object) [
+                    "object_id" => $user->getId(),
+                    "type"      => "user"
+                ];
+            }
+
+            $club = (new Clubs)->getByShortURL($screen_name);
+            if($club) {
+                return (object) [
+                    "object_id" => $club->getId(),
+                    "type"      => "group"
+                ];
+            }
+
+            return (object) [];
+        }
     }
 }


### PR DESCRIPTION
[`screen_name=va11halla`](https://openvk.uk/method/Utils.resolveScreenName?screen_name=va11halla) не работало из-за того, что, оказывается, в `Aliases`, нету всех альясов :/
Поэтому логика переехала на `Users` и `Clubs` полностью

По сути, код позаимствован из [`Web\Presenters\UnknownTextRouteStrategyPresenter.php->renderDelegate`](https://github.com/openvk/openvk/blob/master/Web/Presenters/UnknownTextRouteStrategyPresenter.php) и [`Web/Models/Entities/Club.php->setShortCode`](https://github.com/openvk/openvk/blob/master/Web/Models/Entities/Club.php)

Есть минус:
- Два запроса в `Aliases` подряд, если нужна будет группа