### PR TITLE
feat(notes): images proxy

### DIFF
--- a/Web/Presenters/ImagesProxyPresenter.php
+++ b/Web/Presenters/ImagesProxyPresenter.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace openvk\Web\Presenters;
+
+use openvk\Web\Models\Repositories\{Gifts, Users};
+use openvk\Web\Models\Entities\Notifications\GiftNotification;
+
+final class ImagesProxyPresenter extends OpenVKPresenter
+{
+    const CACHE_EXPIRATION = 1210000;
+
+    private function image(string $contentType, $contentSize, string $raw): void
+    {
+        header("Content-Type: $contentType");
+        header("Content-Size: $contentSize");
+        header("Cache-Control: public, max-age=" . self::CACHE_EXPIRATION);
+        header("X-Accel-Expires: " . self::CACHE_EXPIRATION);
+        exit($raw);
+    }
+
+    private function placeholder(): void
+    {
+        $placeholder = file_get_contents(__DIR__ . "/../static/img/oof.apng");
+        $this->image("image/png", strlen($placeholder), $placeholder);
+    }
+
+    public function renderIndex(): void
+    {
+        $url = base64_decode($this->requestParam("url"));
+        if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
+            $this->placeholder();
+        }
+
+        $ch = curl_init($url);
+        curl_setopt_array($ch, [
+            CURLOPT_HEADER => 0,
+            CURLOPT_URL => $url,
+            CURLOPT_USERAGENT => OPENVK_ROOT_CONF["openvk"]["appearance"]["name"] . ' Images Proxy/1.0',
+            CURLOPT_REFERER => "https://$_SERVER[SERVER_NAME]/",
+            CURLOPT_RETURNTRANSFER => 1,
+            CURLOPT_BINARYTRANSFER => 1,
+        ]);
+
+        $raw = curl_exec($ch);
+        $contentType = curl_getinfo($ch, CURLINFO_CONTENT_TYPE);
+        $contentSize = curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
+
+        curl_close($ch);
+
+        if ($raw && str_contains($contentType, "image")) {
+            $this->image($contentType, $contentSize, $raw);
+        } else {
+            $this->placeholder();
+        }
+    }
+}

--- a/Web/Presenters/ImagesProxyPresenter.php
+++ b/Web/Presenters/ImagesProxyPresenter.php
@@ -26,7 +26,14 @@ final class ImagesProxyPresenter extends OpenVKPresenter
 
     public function renderIndex(): void
     {
-        $url = base64_decode($this->requestParam("url"));
+        $this->assertUserLoggedIn();
+
+        $url = $this->requestParam("url");
+        if (OPENVK_ROOT_CONF["openvk"]["preferences"]["imagesProxy"]["settings"]["base64_decode_url"]) {
+            $url = base64_decode($url);
+        }
+
+        $url = OPENVK_ROOT_CONF["openvk"]["preferences"]["imagesProxy"]["settings"]["url_prefix"] . $url;
         if (!$url || !filter_var($url, FILTER_VALIDATE_URL)) {
             $this->placeholder();
         }

--- a/Web/di.yml
+++ b/Web/di.yml
@@ -49,3 +49,4 @@ services:
     - openvk\Web\Models\Repositories\BannedLinks
     - openvk\Web\Models\Repositories\ChandlerGroups
     - openvk\Web\Presenters\MaintenancePresenter
+    - openvk\Web\Presenters\ImagesProxyPresenter

--- a/Web/routes.yml
+++ b/Web/routes.yml
@@ -349,6 +349,8 @@ routes:
       handler: "About->dev"
     - url: "/tour"
       handler: "About->tour"
+    - url: "/image.php"
+      handler: "ImagesProxy->index"
     - url: "/{?shortCode}"
       handler: "UnknownTextRouteStrategy->delegate"
       placeholders:

--- a/openvk-example.yml
+++ b/openvk-example.yml
@@ -102,6 +102,11 @@ openvk:
             fartscroll: false
             testLabel: false
         defaultMobileTheme: ""
+        imagesProxy:
+            replaceInNotes: true
+            settings:
+                url_prefix: ""
+                base64_decode_url: true
     
     telemetry:
         plausible:


### PR DESCRIPTION
Этот PR добавляет прокси для изображений, который сейчас используется при отображении заметок, где пользователи могут встраивать любые изображения.  Это решает проблему с различными IP-логгерами, так как теперь они получают только IP-адрес сервера, но не пользователя.

Также теперь ссылки в заметках ведут на `/away.php?to=...`.

Resolves #916

![image](https://github.com/openvk/openvk/assets/93197434/fb921ec5-9491-4618-b7d2-acea84c8108a)
