### PR TITLE
Patch array objects for PHP 8.1

### DIFF
--- a/Web/Presenters/WallPresenter.php
+++ b/Web/Presenters/WallPresenter.php
@@ -154,7 +154,7 @@ final class WallPresenter extends OpenVKPresenter
         $this->template->paginatorConf = (object) [
             "count"   => $posts->count(),
             "page"    => (int) ($_GET["p"] ?? 1),
-            "amount"  => sizeof($posts->page((int) ($_GET["p"] ?? 1), $perPage)),
+            "amount"  => $posts->page((int) ($_GET["p"] ?? 1), $perPage)->count(),
             "perPage" => $perPage,
         ];
         $this->template->posts = [];

--- a/Web/Presenters/WallPresenter.php
+++ b/Web/Presenters/WallPresenter.php
@@ -74,7 +74,7 @@ final class WallPresenter extends OpenVKPresenter
         $this->template->paginatorConf = (object) [
             "count"   => $this->template->count,
             "page"    => (int) ($_GET["p"] ?? 1),
-            "amount"  => sizeof((array)$this->template->posts),
+            "amount"  => $this->template->posts->count(),
             "perPage" => OPENVK_DEFAULT_PER_PAGE,
         ];
 
@@ -332,7 +332,7 @@ final class WallPresenter extends OpenVKPresenter
         foreach($photos as $photo)
         	$post->attach($photo);
         
-        if(sizeof($videos) > 0)
+        if($videos->count() > 0)
             foreach($videos as $vid)
                 $post->attach($vid);
         

--- a/Web/Presenters/WallPresenter.php
+++ b/Web/Presenters/WallPresenter.php
@@ -74,7 +74,7 @@ final class WallPresenter extends OpenVKPresenter
         $this->template->paginatorConf = (object) [
             "count"   => $this->template->count,
             "page"    => (int) ($_GET["p"] ?? 1),
-            "amount"  => $this->template->posts->count(),
+            "amount"  => $this->template->posts->getRowCount(),
             "perPage" => OPENVK_DEFAULT_PER_PAGE,
         ];
 
@@ -152,9 +152,9 @@ final class WallPresenter extends OpenVKPresenter
                    ->where("deleted", 0)
                    ->order("created DESC");
         $this->template->paginatorConf = (object) [
-            "count"   => $posts->count(),
+            "count"   => $posts->getRowCount(),
             "page"    => (int) ($_GET["p"] ?? 1),
-            "amount"  => $posts->page((int) ($_GET["p"] ?? 1), $perPage)->count(),
+            "amount"  => $posts->page((int) ($_GET["p"] ?? 1), $perPage)->getRowCount(),
             "perPage" => $perPage,
         ];
         $this->template->posts = [];
@@ -182,7 +182,7 @@ final class WallPresenter extends OpenVKPresenter
         $this->template->paginatorConf = (object) [
             "count"   => $count,
             "page"    => (int) ($_GET["p"] ?? 1),
-            "amount"  => $posts->count(),
+            "amount"  => $posts->getRowCount(),
             "perPage" => $pPage,
         ];
         foreach($posts as $post)

--- a/Web/Presenters/WallPresenter.php
+++ b/Web/Presenters/WallPresenter.php
@@ -74,7 +74,7 @@ final class WallPresenter extends OpenVKPresenter
         $this->template->paginatorConf = (object) [
             "count"   => $this->template->count,
             "page"    => (int) ($_GET["p"] ?? 1),
-            "amount"  => sizeof($this->template->posts),
+            "amount"  => sizeof((array)$this->template->posts),
             "perPage" => OPENVK_DEFAULT_PER_PAGE,
         ];
 
@@ -152,7 +152,7 @@ final class WallPresenter extends OpenVKPresenter
                    ->where("deleted", 0)
                    ->order("created DESC");
         $this->template->paginatorConf = (object) [
-            "count"   => sizeof($posts),
+            "count"   => sizeof((array)$posts),
             "page"    => (int) ($_GET["p"] ?? 1),
             "amount"  => sizeof($posts->page((int) ($_GET["p"] ?? 1), $perPage)),
             "perPage" => $perPage,
@@ -182,7 +182,7 @@ final class WallPresenter extends OpenVKPresenter
         $this->template->paginatorConf = (object) [
             "count"   => $count,
             "page"    => (int) ($_GET["p"] ?? 1),
-            "amount"  => sizeof($posts),
+            "amount"  => sizeof((array)$posts),
             "perPage" => $pPage,
         ];
         foreach($posts as $post)

--- a/Web/Presenters/WallPresenter.php
+++ b/Web/Presenters/WallPresenter.php
@@ -152,7 +152,7 @@ final class WallPresenter extends OpenVKPresenter
                    ->where("deleted", 0)
                    ->order("created DESC");
         $this->template->paginatorConf = (object) [
-            "count"   => sizeof((array)$posts),
+            "count"   => $posts->count(),
             "page"    => (int) ($_GET["p"] ?? 1),
             "amount"  => sizeof($posts->page((int) ($_GET["p"] ?? 1), $perPage)),
             "perPage" => $perPage,
@@ -182,7 +182,7 @@ final class WallPresenter extends OpenVKPresenter
         $this->template->paginatorConf = (object) [
             "count"   => $count,
             "page"    => (int) ($_GET["p"] ?? 1),
-            "amount"  => sizeof((array)$posts),
+            "amount"  => $posts->count(),
             "perPage" => $pPage,
         ];
         foreach($posts as $post)

--- a/Web/Presenters/templates/Admin/Logs.xml
+++ b/Web/Presenters/templates/Admin/Logs.xml
@@ -9,7 +9,7 @@
 {/block}
 
 {block content}
-    {var $amount = sizeof($logs)}
+    {var $amount = sizeof((array)$logs)}
 
     <style>
         del, ins { text-decoration: none; color: #000; }

--- a/Web/Presenters/templates/Admin/Logs.xml
+++ b/Web/Presenters/templates/Admin/Logs.xml
@@ -9,7 +9,7 @@
 {/block}
 
 {block content}
-    {var $amount = sizeof((array)$logs)}
+    {var $amount = $logs->count()}
 
     <style>
         del, ins { text-decoration: none; color: #000; }

--- a/Web/Presenters/templates/Admin/Logs.xml
+++ b/Web/Presenters/templates/Admin/Logs.xml
@@ -9,7 +9,7 @@
 {/block}
 
 {block content}
-    {var $amount = $logs->count()}
+    {var $amount = $logs->getRowCount()}
 
     <style>
         del, ins { text-decoration: none; color: #000; }

--- a/Web/Presenters/templates/Search/Index.xml
+++ b/Web/Presenters/templates/Search/Index.xml
@@ -142,7 +142,7 @@
     {include "../components/paginator.xml", conf => (object) [
         "page"     => $page,
         "count"    => $count,
-        "amount"   => sizeof($data),
+        "amount"   => sizeof((array)$data),
         "perPage"  => $perPage ?? OPENVK_DEFAULT_PER_PAGE,
         "atBottom" => false,
     ]}

--- a/Web/Presenters/templates/Search/Index.xml
+++ b/Web/Presenters/templates/Search/Index.xml
@@ -142,7 +142,7 @@
     {include "../components/paginator.xml", conf => (object) [
         "page"     => $page,
         "count"    => $count,
-        "amount"   => sizeof((array)$data),
+        "amount"   => $data->count(),
         "perPage"  => $perPage ?? OPENVK_DEFAULT_PER_PAGE,
         "atBottom" => false,
     ]}

--- a/Web/Presenters/templates/Search/Index.xml
+++ b/Web/Presenters/templates/Search/Index.xml
@@ -142,7 +142,7 @@
     {include "../components/paginator.xml", conf => (object) [
         "page"     => $page,
         "count"    => $count,
-        "amount"   => $data->count(),
+        "amount"   => $data->getRowCount(),
         "perPage"  => $perPage ?? OPENVK_DEFAULT_PER_PAGE,
         "atBottom" => false,
     ]}


### PR DESCRIPTION
На PHP 8.1 не отдавался правильный тип массивов при составлении ленты новостей, поиска, логов и т. д.
![SCR_20231021_225852_firefox](https://github.com/openvk/openvk/assets/76806170/16d9d054-198f-40c0-bbea-ff49c77eeae0)
Теперь я решил эту проблему путём вставки `(array)` перед именем переменной массива. С PHP 7.4 я не уверен, что будет работать примерно также, как с PHP 8.1, но вы посмотрите.
![SCR_20231025_160703_firefox](https://github.com/openvk/openvk/assets/76806170/933a6004-e42f-4216-ba97-bbecc094f949)

