### PR TITLE
fix(DateTime): use php81_bc/strftime

### DIFF
--- a/Web/Models/Entities/Message.php
+++ b/Web/Models/Entities/Message.php
@@ -66,7 +66,7 @@ class Message extends RowModel
         $dateTime = new DateTime($this->getRecord()->created);
 
         if($dateTime->format("%d.%m.%y") == ovk_strftime_safe("%d.%m.%y", time())) {
-            return $dateTime->format("%T %p");
+            return $dateTime->format("%T");
         } else {
             return $dateTime->format("%d.%m.%y");
         }

--- a/Web/Util/DateTime.php
+++ b/Web/Util/DateTime.php
@@ -22,21 +22,21 @@ class DateTime
         $now  = date_create();
         $diff = date_diff($now, $then);
         if($diff->invert === 0)
-            return ovk_strftime_safe("%e %B %Y ", $this->timestamp) . tr("time_at_sp") . ovk_strftime_safe(" %R %p", $this->timestamp);
+            return ovk_strftime_safe("%e %B %Y ", $this->timestamp) . tr("time_at_sp") . ovk_strftime_safe(" %R", $this->timestamp);
         
         if($this->timestamp >= strtotime("midnight")) { # Today
             if($diff->h >= 1)
-                return tr("time_today") . tr("time_at_sp") . ovk_strftime_safe(" %R %p", $this->timestamp);
+                return tr("time_today") . tr("time_at_sp") . ovk_strftime_safe(" %R", $this->timestamp);
             else if($diff->i < 2)
                 return tr("time_just_now");
             else
                 return $diff->i === 5 ? tr("time_exactly_five_minutes_ago") : tr("time_minutes_ago", $diff->i);
         } else if($this->timestamp >= strtotime("-1day midnight")) { # Yesterday
-            return tr("time_yesterday") . tr("time_at_sp") . ovk_strftime_safe(" %R %p", $this->timestamp);
+            return tr("time_yesterday") . tr("time_at_sp") . ovk_strftime_safe(" %R", $this->timestamp);
         } else if(ovk_strftime_safe("%Y", $this->timestamp) === ovk_strftime_safe("%Y", time())) { # In this year
-            return ovk_strftime_safe("%e %h ", $this->timestamp) . tr("time_at_sp") . ovk_strftime_safe(" %R %p", $this->timestamp);
+            return ovk_strftime_safe("%e %h ", $this->timestamp) . tr("time_at_sp") . ovk_strftime_safe(" %R", $this->timestamp);
         } else {
-            return ovk_strftime_safe("%e %B %Y ", $this->timestamp) . tr("time_at_sp") . ovk_strftime_safe(" %R %p", $this->timestamp);
+            return ovk_strftime_safe("%e %B %Y ", $this->timestamp) . tr("time_at_sp") . ovk_strftime_safe(" %R", $this->timestamp);
         }
     }
     

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -3,6 +3,7 @@ use Chandler\Database\DatabaseConnection;
 use Chandler\Session\Session;
 use openvk\Web\Util\Localizator;
 use openvk\Web\Util\Bitmask;
+use function PHP81_BC\strftime;
 
 function _ovk_check_environment(): void
 {
@@ -198,7 +199,7 @@ function ovk_proc_strtrim(string $string, int $length = 0): string
 function ovk_strftime_safe(string $format, ?int $timestamp = NULL): string
 {
     $sessionOffset = intval(Session::i()->get("_timezoneOffset"));
-    $str = strftime($format, $timestamp + ($sessionOffset * MINUTE) * -1 ?? time() + ($sessionOffset * MINUTE) * -1);
+    $str = strftime($format, $timestamp + ($sessionOffset * MINUTE) * -1 ?? time() + ($sessionOffset * MINUTE) * -1, tr("__locale") !== '@__locale' ? tr("__locale") : NULL);
     if(PHP_SHLIB_SUFFIX === "dll") {
         $enc = tr("__WinEncoding");
         if($enc === "@__WinEncoding")

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "ext-simplexml": "*",
         "symfony/console": "5.4.x-dev",
         "wapmorgan/morphos": "dev-master",
-        "ext-sodium": "*"
+        "ext-sodium": "*",
+        "php81_bc/strftime": "^0.0.2"
     },
     "minimum-stability": "dev"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "636b9c2de242c3485ec3924bc662629e",
+    "content-hash": "21afd8f0eb467e72345f83515fefb511",
     "packages": [
         {
             "name": "al/emoji-detector",
@@ -1009,6 +1009,46 @@
                 "source": "https://github.com/lfkeitel/php-totp/tree/v1.1.0"
             },
             "time": "2022-04-07T20:52:00+00:00"
+        },
+        {
+            "name": "php81_bc/strftime",
+            "version": "0.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/alphp/strftime.git",
+                "reference": "a6b25e3e2ee931faf3d80bb5c0fba3552300d02a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/alphp/strftime/zipball/a6b25e3e2ee931faf3d80bb5c0fba3552300d02a",
+                "reference": "a6b25e3e2ee931faf3d80bb5c0fba3552300d02a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/php-8.1-strftime.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fernando Herrero",
+                    "homepage": "https://github.com/alphp/strftime/graphs/contributors"
+                }
+            ],
+            "description": "Locale-formatted strftime using IntlDateFormatter (PHP 8.1 compatible)",
+            "support": {
+                "issues": "https://github.com/alphp/strftime/issues",
+                "source": "https://github.com/alphp/strftime"
+            },
+            "time": "2022-03-13T01:43:11+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
Native strftime was deprecated in PHP 8.1 so I replaced it with an alternative library that uses ICU so that you don't have to set up locales on your server anymore.
Also this commit removes AM/PM labels as timestamps were in 24h format anyways, regardless of locale.