### PR TITLE
Fix button width

### DIFF
--- a/Web/Presenters/templates/User/View.xml
+++ b/Web/Presenters/templates/User/View.xml
@@ -766,8 +766,6 @@
         <script n:if="isset($thisUser) && $user->getId() == $thisUser->getId()" n:syntax="off">
             function setStatusEditorShown(shown) {
                 document.getElementById("status_editor").style.display = shown ? "block" : "none";
-                if(!document.status_popup_form.submit.style.width)
-                    document.status_popup_form.submit.style.width = document.status_popup_form.submit.offsetWidth + 4 + "px"
             }
 
             document.addEventListener("click", event => {


### PR DESCRIPTION
Воспроизведение:
- Открыть свою страницу
- Нажать на ПУСТОЕ место на странице
- Нажать на редактирование статуса

<img width="377" alt="Screen Shot 2024-01-17 at 15 10 36" src="https://github.com/openvk/openvk/assets/99194003/1e18a042-f7cf-4a34-948f-0a6e15bf1372">

Этот пиздец происходит потому что вы задаете за каким то хуем ширину кнопке насиально (когда и с автоматической все прекрасно). Но мало этого так вы это делаете и при "закрытии окна" которое повешено на клик куда угодно на странице. Тем самым поскольку у окна по дефолту стоит `display: none` то offsetWidth для всех элементов будет равен нулю. И кнопке будет задан `0 + 4 = 4px` ширины.