### PR TITLE
ci(actions): run build action everywhere

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,14 +48,11 @@ jobs:
           images: |
             ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}
           tags: |
-            type=sha
-            type=ref,event=branch
-            type=ref,event=pr
-            type=ref,event=tag
-            type=raw,value=,enable={{is_default_branch}}
-          flavor: |
-            latest=auto
-            prefix=${{env.DB_VERSION}}-primary
+            type=sha,prefix=${{env.DB_VERSION}}-primary-
+            type=ref,event=branch,prefix=${{env.DB_VERSION}}-primary-
+            type=ref,event=pr,prefix=${{env.DB_VERSION}}-primary-
+            type=ref,event=tag,prefix=${{env.DB_VERSION}}-primary-
+            type=raw,value=${{env.DB_VERSION}}-primary,enable={{is_default_branch}}
 
       - name: MariaDB event meta
         id: db-eventmeta
@@ -64,14 +61,11 @@ jobs:
           images: |
             ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}
           tags: |
-            type=sha
-            type=ref,event=branch
-            type=ref,event=pr
-            type=ref,event=tag
-            type=raw,value=,enable={{is_default_branch}}
-          flavor: |
-            latest=auto
-            prefix=${{env.DB_VERSION}}-eventdb-
+            type=sha,prefix=${{env.DB_VERSION}}-eventdb-
+            type=ref,event=branch,prefix=${{env.DB_VERSION}}-eventdb-
+            type=ref,event=pr,prefix=${{env.DB_VERSION}}-eventdb-
+            type=ref,event=tag,prefix=${{env.DB_VERSION}}-eventdb-
+            type=raw,value=${{env.DB_VERSION}}-eventdb,enable={{is_default_branch}}
 
       # - name: Log into registry
       #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,8 +46,9 @@ jobs:
             type=ref,event=tag
             type=raw,value=latest,enable={{is_default_branch}}
 
-      # - name: Log into registry
-      #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Log into registry
+        if: github.event_name != 'pull_request'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build base image
         uses: docker/build-push-action@v6
@@ -56,6 +57,7 @@ jobs:
           file: install/automated/docker/openvk.Dockerfile
           tags: ${{ steps.basemeta.outputs.tags }}
           labels: ${{ steps.basemeta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             GITREPO=${{ steps.repositorystring.outputs.lowercase }}
 
@@ -115,12 +117,14 @@ jobs:
             type=ref,event=tag,prefix=${{env.DB_VERSION}}-eventdb-
             type=raw,value=${{env.DB_VERSION}}-eventdb,enable={{is_default_branch}}
 
-      # - name: Log into registry
-      #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Log into registry
+        if: github.event_name != 'pull_request'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
       
       - name: Build MariaDB primary image
         uses: docker/build-push-action@v6
         with:
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/${{matrix.platform}}
           file: install/automated/docker/mariadb-primary.Dockerfile
           tags: ${{ steps.db-primarymeta.outputs.tags }}
@@ -131,6 +135,7 @@ jobs:
       - name: Build MariaDB event image
         uses: docker/build-push-action@v6
         with:
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/${{matrix.platform}}
           file: install/automated/docker/mariadb-eventdb.Dockerfile
           tags: ${{ steps.db-eventmeta.outputs.tags }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,6 @@
 name: Build images
 
-on:
-  push:
+on: [push, pull_request]
 
 env:
   BASE_IMAGE_NAME: openvk

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,53 +28,80 @@ jobs:
         with:
           string: ${{ github.repository }}
 
+      - name: Base image meta
+        id: basemeta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.BASE_IMAGE_NAME}}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: MariaDB primary meta
+        id: db-primarymeta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=raw,value=,enable={{is_default_branch}}
+          flavor: |
+            latest=auto
+            prefix=${{env.DB_VERSION}}-primary
+
+      - name: MariaDB event meta
+        id: db-eventmeta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
+            type=raw,value=,enable={{is_default_branch}}
+          flavor: |
+            latest=auto
+            prefix=${{env.DB_VERSION}}-eventdb-
+
       # - name: Log into registry
       #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
-          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.BASE_IMAGE_NAME}}:test
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/openvk.Dockerfile
-          outputs: type=oci,dest=/tmp/openvk.tar
+          tags: ${{ steps.basemeta.outputs.tags }}
+          labels: ${{ steps.basemeta.outputs.labels }}
           build-args: |
             GITREPO=${{ steps.repositorystring.outputs.lowercase }}
       
       - name: Build MariaDB primary image
         uses: docker/build-push-action@v6
         with:
-          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-primary
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-primary.Dockerfile
-          outputs: type=oci,dest=/tmp/mariadb-primary.tar
+          tags: ${{ steps.db-primarymeta.outputs.tags }}
+          labels: ${{ steps.db-primarymeta.outputs.labels }}
           build-args: |
             VERSION=${{env.DB_VERSION}}
       
       - name: Build MariaDB event image
         uses: docker/build-push-action@v6
         with:
-          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-eventdb
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-eventdb.Dockerfile
-          outputs: type=oci,dest=/tmp/mariadb-eventdb.tar
+          tags: ${{ steps.db-eventmeta.outputs.tags }}
+          labels: ${{ steps.db-eventmeta.outputs.labels }}
           build-args: |
             VERSION=${{env.DB_VERSION}}
-      
-      - name: Upload base image as an artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: openvk
-          path: /tmp/openvk.tar
-      
-      - name: Upload MariaDB primary as an artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mariadb-primary
-          path: /tmp/mariadb-primary.tar
-      
-      - name: Upload MariaDB event as an artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mariadb-eventdb
-          path: /tmp/mariadb-eventdb.tar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,13 +2,6 @@ name: Build images
 
 on:
   push:
-    # Publish `master` as Docker `latest` image.
-    branches:
-      - master
-
-    # Publish `v1.2.3` tags as releases.
-    tags:
-      - v*
 
 env:
   BASE_IMAGE_NAME: openvk
@@ -19,22 +12,15 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        arch: ['x86_64']
 
     if: github.event_name == 'push'
     steps:
-      - uses: actions/checkout@v3
-        with:
-          lfs: false
-      
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Change repository string to lowercase
         id: repositorystring
@@ -42,29 +28,32 @@ jobs:
         with:
           string: ${{ github.repository }}
 
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      # - name: Log into registry
+      #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Build base image
-        run: |
-          IMAGE_ID=ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$BASE_IMAGE_NAME
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          [ "$VERSION" == "master" ] && VERSION=latest
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-
-          docker buildx build --platform linux/amd64,linux/arm64 -t $IMAGE_ID:$VERSION . --push -f install/automated/docker/openvk.Dockerfile --build-arg GITREPO=${{ steps.repositorystring.outputs.lowercase }}
+        uses: docker/build-push-action@v6
+        with:
+          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$BASE_IMAGE_NAME:test
+          platforms: linux/amd64,linux/arm64
+          file: install/automated/docker/openvk.Dockerfile
+          build-args: |
+            GITREPO=${{ steps.repositorystring.outputs.lowercase }}
       
       - name: Build MariaDB primary image
-        run: |
-          IMAGE_NAME=ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$DB_IMAGE_NAME:$DB_VERSION-primary
-
-          docker buildx build --platform linux/amd64,linux/arm64 -t $IMAGE_NAME . --push -f install/automated/docker/mariadb-primary.Dockerfile --build-arg VERSION=$DB_VERSION
+        uses: docker/build-push-action@v6
+        with:
+          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$DB_IMAGE_NAME:$DB_VERSION-primary
+          platforms: linux/amd64,linux/arm64
+          file: install/automated/docker/mariadb-primary.Dockerfile
+          build-args: |
+            VERSION=$DB_VERSION
       
       - name: Build MariaDB event image
-        run: |
-          IMAGE_NAME=ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$EVENT_IMAGE_NAME:$DB_VERSION-eventdb
-
-          docker buildx build --platform linux/amd64,linux/arm64 -t $IMAGE_NAME . --push -f install/automated/docker/mariadb-eventdb.Dockerfile --build-arg VERSION=$DB_VERSION
+        uses: docker/build-push-action@v6
+        with:
+          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$DB_IMAGE_NAME:$DB_VERSION-eventdb
+          platforms: linux/amd64,linux/arm64
+          file: install/automated/docker/mariadb-eventdb.Dockerfile
+          build-args: |
+            VERSION=$DB_VERSION

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.BASE_IMAGE_NAME}}:test
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/openvk.Dockerfile
-          outputs: type=docker,dest=/tmp/openvk.tar
+          outputs: type=oci,dest=/tmp/openvk.tar
           build-args: |
             GITREPO=${{ steps.repositorystring.outputs.lowercase }}
       
@@ -47,7 +47,7 @@ jobs:
           tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-primary
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-primary.Dockerfile
-          outputs: type=docker,dest=/tmp/mariadb-primary.tar
+          outputs: type=oci,dest=/tmp/mariadb-primary.tar
           build-args: |
             VERSION=${{env.DB_VERSION}}
       
@@ -57,7 +57,7 @@ jobs:
           tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-eventdb
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-eventdb.Dockerfile
-          outputs: type=docker,dest=/tmp/mariadb-eventdb.tar
+          outputs: type=oci,dest=/tmp/mariadb-eventdb.tar
           build-args: |
             VERSION=${{env.DB_VERSION}}
       

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,8 @@ jobs:
         with:
           images: |
             ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.BASE_IMAGE_NAME}}
+          labels: |
+            org.opencontainers.image.documentation=https://github.com/OpenVK/openvk/blob/master/install/automated/docker/Readme.md
           tags: |
             type=sha
             type=ref,event=branch
@@ -57,7 +59,7 @@ jobs:
           labels: ${{ steps.basemeta.outputs.labels }}
           build-args: |
             GITREPO=${{ steps.repositorystring.outputs.lowercase }}
-            
+
   builddb:
     name: Build DB images
     strategy:
@@ -86,6 +88,10 @@ jobs:
         with:
           images: |
             ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}
+          labels: |
+            org.opencontainers.image.title=OpenVK MariaDB (Primary)
+            org.opencontainers.image.description=OpenVK's image for MariaDB for primary database.
+            org.opencontainers.image.documentation=https://github.com/OpenVK/openvk/blob/master/install/automated/docker/Readme.md
           tags: |
             type=sha,prefix=${{env.DB_VERSION}}-primary-sha-
             type=ref,event=branch,prefix=${{env.DB_VERSION}}-primary-
@@ -99,6 +105,10 @@ jobs:
         with:
           images: |
             ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}
+          labels: |
+            org.opencontainers.image.title=OpenVK MariaDB (EventDB)
+            org.opencontainers.image.description=OpenVK's image for MariaDB for event database.
+            org.opencontainers.image.documentation=https://github.com/OpenVK/openvk/blob/master/install/automated/docker/Readme.md
           tags: |
             type=sha,prefix=${{env.DB_VERSION}}-eventdb-sha-
             type=ref,event=branch,prefix=${{env.DB_VERSION}}-eventdb-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,6 +37,7 @@ jobs:
           tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.BASE_IMAGE_NAME}}:test
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/openvk.Dockerfile
+          load: true
           build-args: |
             GITREPO=${{ steps.repositorystring.outputs.lowercase }}
       
@@ -46,6 +47,7 @@ jobs:
           tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-primary
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-primary.Dockerfile
+          load: true
           build-args: |
             VERSION=${{env.DB_VERSION}}
       
@@ -55,5 +57,6 @@ jobs:
           tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-eventdb
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-eventdb.Dockerfile
+          load: true
           build-args: |
             VERSION=${{env.DB_VERSION}}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,9 +48,9 @@ jobs:
           images: |
             ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}
           tags: |
-            type=sha,prefix=${{env.DB_VERSION}}-primary-
+            type=sha,prefix=${{env.DB_VERSION}}-primary-sha-
             type=ref,event=branch,prefix=${{env.DB_VERSION}}-primary-
-            type=ref,event=pr,prefix=${{env.DB_VERSION}}-primary-
+            type=ref,event=pr,prefix=${{env.DB_VERSION}}-primary-pr-
             type=ref,event=tag,prefix=${{env.DB_VERSION}}-primary-
             type=raw,value=${{env.DB_VERSION}}-primary,enable={{is_default_branch}}
 
@@ -61,9 +61,9 @@ jobs:
           images: |
             ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}
           tags: |
-            type=sha,prefix=${{env.DB_VERSION}}-eventdb-
+            type=sha,prefix=${{env.DB_VERSION}}-eventdb-sha-
             type=ref,event=branch,prefix=${{env.DB_VERSION}}-eventdb-
-            type=ref,event=pr,prefix=${{env.DB_VERSION}}-eventdb-
+            type=ref,event=pr,prefix=${{env.DB_VERSION}}-eventdb-pr-
             type=ref,event=tag,prefix=${{env.DB_VERSION}}-eventdb-
             type=raw,value=${{env.DB_VERSION}}-eventdb,enable={{is_default_branch}}
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
           tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.BASE_IMAGE_NAME}}:test
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/openvk.Dockerfile
-          load: true
+          outputs: type=docker,dest=/tmp/openvk.tar
           build-args: |
             GITREPO=${{ steps.repositorystring.outputs.lowercase }}
       
@@ -47,7 +47,7 @@ jobs:
           tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-primary
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-primary.Dockerfile
-          load: true
+          outputs: type=docker,dest=/tmp/mariadb-primary.tar
           build-args: |
             VERSION=${{env.DB_VERSION}}
       
@@ -57,6 +57,24 @@ jobs:
           tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-eventdb
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-eventdb.Dockerfile
-          load: true
+          outputs: type=docker,dest=/tmp/mariadb-eventdb.tar
           build-args: |
             VERSION=${{env.DB_VERSION}}
+      
+      - name: Upload base image as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openvk
+          path: /tmp/openvk.tar
+      
+      - name: Upload MariaDB primary as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mariadb-primary
+          path: /tmp/mariadb-primary.tar
+      
+      - name: Upload MariaDB event as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mariadb-eventdb
+          path: /tmp/mariadb-eventdb.tar

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,7 +34,8 @@ jobs:
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
-          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$BASE_IMAGE_NAME:test
+          tags: |
+            ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$BASE_IMAGE_NAME:test
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/openvk.Dockerfile
           build-args: |
@@ -43,7 +44,8 @@ jobs:
       - name: Build MariaDB primary image
         uses: docker/build-push-action@v6
         with:
-          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$DB_IMAGE_NAME:$DB_VERSION-primary
+          tags: |
+            ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$DB_IMAGE_NAME:$DB_VERSION-primary
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-primary.Dockerfile
           build-args: |
@@ -52,7 +54,8 @@ jobs:
       - name: Build MariaDB event image
         uses: docker/build-push-action@v6
         with:
-          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$DB_IMAGE_NAME:$DB_VERSION-eventdb
+          tags: |
+            ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$DB_IMAGE_NAME:$DB_VERSION-eventdb
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-eventdb.Dockerfile
           build-args: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,14 +10,14 @@ env:
   DB_VERSION: "10.9"
 
 jobs:
-  build:
+  buildbase:
+    name: Build base images
     strategy:
       matrix:
         platform: [amd64, arm64]
 
     runs-on: ubuntu-latest
 
-    if: github.event_name == 'push'
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -44,6 +44,41 @@ jobs:
             type=ref,event=pr
             type=ref,event=tag
             type=raw,value=latest,enable={{is_default_branch}}
+
+      # - name: Log into registry
+      #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build base image
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/${{matrix.platform}}
+          file: install/automated/docker/openvk.Dockerfile
+          tags: ${{ steps.basemeta.outputs.tags }}
+          labels: ${{ steps.basemeta.outputs.labels }}
+          build-args: |
+            GITREPO=${{ steps.repositorystring.outputs.lowercase }}
+            
+  builddb:
+    name: Build DB images
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Change repository string to lowercase
+        id: repositorystring
+        uses: Entepotenz/change-string-case-action-min-dependencies@v1.1.0
+        with:
+          string: ${{ github.repository }}
 
       - name: MariaDB primary meta
         id: db-primarymeta
@@ -73,16 +108,6 @@ jobs:
 
       # - name: Log into registry
       #   run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Build base image
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/${{matrix.platform}}
-          file: install/automated/docker/openvk.Dockerfile
-          tags: ${{ steps.basemeta.outputs.tags }}
-          labels: ${{ steps.basemeta.outputs.labels }}
-          build-args: |
-            GITREPO=${{ steps.repositorystring.outputs.lowercase }}
       
       - name: Build MariaDB primary image
         uses: docker/build-push-action@v6

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,8 +34,7 @@ jobs:
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
-          tags: |
-            ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$BASE_IMAGE_NAME:test
+          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.BASE_IMAGE_NAME}}:test
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/openvk.Dockerfile
           build-args: |
@@ -44,19 +43,17 @@ jobs:
       - name: Build MariaDB primary image
         uses: docker/build-push-action@v6
         with:
-          tags: |
-            ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$DB_IMAGE_NAME:$DB_VERSION-primary
+          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-primary
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-primary.Dockerfile
           build-args: |
-            VERSION=$DB_VERSION
+            VERSION=${{env.DB_VERSION}}
       
       - name: Build MariaDB event image
         uses: docker/build-push-action@v6
         with:
-          tags: |
-            ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/$DB_IMAGE_NAME:$DB_VERSION-eventdb
+          tags: ghcr.io/${{ steps.repositorystring.outputs.lowercase }}/${{env.DB_IMAGE_NAME}}:${{env.DB_VERSION}}-eventdb
           platforms: linux/amd64,linux/arm64
           file: install/automated/docker/mariadb-eventdb.Dockerfile
           build-args: |
-            VERSION=$DB_VERSION
+            VERSION=${{env.DB_VERSION}}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,10 @@ env:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
+
     runs-on: ubuntu-latest
 
     if: github.event_name == 'push'
@@ -73,7 +77,7 @@ jobs:
       - name: Build base image
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{matrix.platform}}
           file: install/automated/docker/openvk.Dockerfile
           tags: ${{ steps.basemeta.outputs.tags }}
           labels: ${{ steps.basemeta.outputs.labels }}
@@ -83,7 +87,7 @@ jobs:
       - name: Build MariaDB primary image
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{matrix.platform}}
           file: install/automated/docker/mariadb-primary.Dockerfile
           tags: ${{ steps.db-primarymeta.outputs.tags }}
           labels: ${{ steps.db-primarymeta.outputs.labels }}
@@ -93,7 +97,7 @@ jobs:
       - name: Build MariaDB event image
         uses: docker/build-push-action@v6
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/${{matrix.platform}}
           file: install/automated/docker/mariadb-eventdb.Dockerfile
           tags: ${{ steps.db-eventmeta.outputs.tags }}
           labels: ${{ steps.db-eventmeta.outputs.labels }}


### PR DESCRIPTION
Глубокая переработка процесса сборки:

* Теперь используются предоставляемые докером экшны вроде `docker/build-push-action@v6` и `docker/metadata-action@v5`.
* Теперь сборка осуществляется при любом пуше и пул-реквесте.
* Все сборки заливаются в регистри если это не пул-реквесты.
* Теперь сборки разных образов идут параллельно, что ускоряет выполнение экшена.
* Система тегов:
  * Любой коммит — `:sha-6cf7a70`
  * Пул-реквест — `:pr-0000`
  * Ветка в репозитории — `:branch`
  * Тег — `:tag`
  * master-ветка — `:latest`