### PR TITLE
Remove min-height from dialogue boxes

### DIFF
--- a/Web/static/css/dialog.css
+++ b/Web/static/css/dialog.css
@@ -16,7 +16,6 @@ body.dimmed > .dimmer #absolute_territory {
     z-index: 1024;
     position: fixed;
     width: 420px;
-    min-height: 200px;
     top: 50%;
     left: 50%;
     margin-right: -50%;
@@ -50,7 +49,6 @@ body.dimmed > .dimmer #absolute_territory {
 
 .ovk-diag-body {
     padding: 20px;
-    min-height: 110px;
 }
 
 .ovk-diag-action {


### PR DESCRIPTION
I don't think setting a minimum height serves any purpose. It leaves an ugly blank space on dialogues that have text smaller than 110px though.