### PR TITLE
Make /token more compatible with vk api

### DIFF
--- a/Web/Presenters/VKAPIPresenter.php
+++ b/Web/Presenters/VKAPIPresenter.php
@@ -344,6 +344,7 @@ final class VKAPIPresenter extends OpenVKPresenter
             "expires_in"   => 0,
             "user_id"      => $uId,
             "is_stale"     => $tokenIsStale,
+            "secret"       => "super_secret_value",
         ]);
         
         $size = strlen($payload);


### PR DESCRIPTION
В оригинальном api вконтакте, /token помимо самого токена, возвращает secret
Он нигде не используется, но требуется официальными клиентами