### PR TITLE
fix(locale-en): change the phrasing for undoing a friend request

### DIFF
--- a/locales/en.strings
+++ b/locales/en.strings
@@ -318,7 +318,7 @@
 "follower" = "Follower";
 "friends_add" = "Add to friends";
 "friends_delete" = "Remove from friends";
-"friends_reject" = "Reject request";
+"friends_reject" = "Cancel request";
 "friends_accept" = "Accept request";
 "friends_leave_in_flw" = "Leave in followers";
 "friends_add_msg" = "Now you're friends.";


### PR DESCRIPTION
"friends_leave_in_flw" is used to reject someone's friend request. This string is used to cancel an outgoing request.