### PR TITLE
fix(messagebox): make dialogue content scrollable and remove `height` from dialogue header and action boxes

### DIFF
--- a/Web/static/css/dialog.css
+++ b/Web/static/css/dialog.css
@@ -38,7 +38,6 @@ body.dimmed > .dimmer #absolute_territory {
 }
 
 .ovk-diag-head {
-    height: 25%;
     padding: 5px;
     background-color: #757575;
     border-bottom: 1px solid #3e3e3e;
@@ -49,11 +48,12 @@ body.dimmed > .dimmer #absolute_territory {
 
 .ovk-diag-body {
     padding: 20px;
+    overflow-y: auto;
+    max-height: 80vh
 }
 
 .ovk-diag-action {
     padding: 10px;
-    height: 25%;
     background-color: #d4d4d4;
     text-align: right;
 }


### PR DESCRIPTION
![dialogue box going off the screen](https://github.com/user-attachments/assets/2eba8bf3-6a9d-4158-a1af-cba8bd3ed513)

https://github.com/user-attachments/assets/f8dab771-5f11-48f7-b592-be64bbd6a28a

Sometimes dialogue boxes get too long and end up going off the screen, making the content impossible to see. This change fixes that by allowing the dialogue content to scroll. It also removes some height restrictions from the header and action sections since they didn’t seem to serve a clear purpose (to me) and might have been causing layout issues.