### PR TITLE
chore(statistics): change behavior of active users count

### DIFF
--- a/Web/Models/Repositories/Users.php
+++ b/Web/Models/Repositories/Users.php
@@ -157,7 +157,7 @@ class Users
     {
         return (object) [
             "all"    => (clone $this->users)->count('*'),
-            "active" => (clone $this->users)->where("online > 0")->count('*'),
+            "active" => (clone $this->users)->where("online >= ?", time() - MONTH)->count('*'),
             "online" => (clone $this->users)->where("online >= ?", time() - 900)->count('*'),
         ];
     }


### PR DESCRIPTION
@WerySkok намекнул на странный подсчёт числа активных пользователей. По факту это был просто подсчёт пользователей, активировавших свои аккаунты за всё время существования инстанса. Теперь он посчитывает активных пользователей в месяц