### PR TITLE
feat(audio): deprecate private access to audio.get manifest and keys fields

### DIFF
--- a/VKAPI/Handlers/Audio.php
+++ b/VKAPI/Handlers/Audio.php
@@ -21,13 +21,7 @@ final class Audio extends VKAPIRequestHandler
             $this->fail(201, "Access denied to audio(" . $audio->getId() . ")");
         }
 
-        # рофлан ебало
-        $privApi  = $hash && $GLOBALS["csrfCheck"];
         $audioObj = $audio->toVkApiStruct($this->getUser());
-        if (!$privApi) {
-            $audioObj->manifest = false;
-            $audioObj->keys     = false;
-        }
 
         if ($need_user) {
             $user = (new \openvk\Web\Models\Repositories\Users())->get($audio->getOwner()->getId());


### PR DESCRIPTION
Как и сказано, непонятно зачем, но получать музыку через апи можно исключительно через original URLs, почему??)))

Меня попросили просто убрать эту проверку.