### PR TITLE
ci(compose): prevent Docker from creating required paths by using verbose bind syntax

### DIFF
--- a/install/automated/docker/docker-compose.yml
+++ b/install/automated/docker/docker-compose.yml
@@ -12,8 +12,18 @@ services:
       - openvk-audios:/opt/chandler/extensions/available/openvk/tmp/api-storage/audios
       - openvk-photos:/opt/chandler/extensions/available/openvk/tmp/api-storage/photos
       - openvk-videos:/opt/chandler/extensions/available/openvk/tmp/api-storage/videos
-      - ./openvk.yml:/opt/chandler/extensions/available/openvk/openvk.yml:ro
-      - ./chandler.yml:/opt/chandler/chandler.yml:ro
+      - type: bind
+        source: ./openvk.yml
+        target: /opt/chandler/extensions/available/openvk/openvk.yml
+        read_only: true
+        bind:
+          create_host_path: false
+      - type: bind
+        source: ./chandler.yml
+        target: /opt/chandler/chandler.yml
+        read_only: true
+        bind:
+          create_host_path: false
     depends_on:
       - acl_handler
       - mariadb-primary
@@ -31,7 +41,12 @@ services:
       - openvk-audios:/opt/chandler/extensions/available/openvk/tmp/api-storage/audios
       - openvk-photos:/opt/chandler/extensions/available/openvk/tmp/api-storage/photos
       - openvk-videos:/opt/chandler/extensions/available/openvk/tmp/api-storage/videos
-      - ./acl_handler.sh:/bin/acl_handler.sh:ro
+      - type: bind
+        source: ./acl_handler.sh
+        target: /bin/acl_handler.sh
+        read_only: true
+        bind:
+          create_host_path: false
 
   mariadb-primary:
     image: ghcr.io/openvk/openvk/mariadb:10.9-primary


### PR DESCRIPTION
Позволяет композу в начале выкинуть ошибку при отсутствии `./openvk.yml`, `./chandler.yml` и `./acl_handler.sh` вместо создания пустых директорий.

<img width="631" height="139" alt="изображение" src="https://github.com/user-attachments/assets/0bf78e95-4965-4578-9d2c-fd69210f8a83" />
