### PR TITLE
fix(ui): prevent hidden .toTop from overlapping buttons

### DIFF
--- a/Web/Presenters/templates/@layout.xml
+++ b/Web/Presenters/templates/@layout.xml
@@ -89,12 +89,12 @@
             </div>
         {/if}
 
-        <div class="toTop">
+        <div class="toTop hidden">
             <div id='to_up'>
                 <svg id="to_up_icon" viewBox="0 0 10 6"><polygon points="0 6 5 0 10 6 0 6"/></svg>
                 <span>{_to_top}</span>
             </div>
-            
+
             <div id='to_back'>
                 <svg id="to_back_icon" viewBox="0 0 10 6"><polygon points="0 0 5 6 10 0 0 0"/></svg>
             </div>
@@ -197,7 +197,7 @@
                                 </object>
                             </a>
                             <a href="/settings" class="link">{_my_settings}</a>
-                            
+
                             {if $thisUser->getLeftMenuItemStatus('docs') || $thisUser->getLeftMenuItemStatus('apps')}
                                 <div class="menu_divider"></div>
                                 <a n:if="$thisUser->getLeftMenuItemStatus('apps')" href="/apps?act=installed" class="link">{_apps}</a>
@@ -273,14 +273,14 @@
                                     {tr("bday_reminder_text", $isBdayToday ? tr("bday_today") : tr("bday_tomorrow"), $bdayListHtml)|noescape}
                                 </text>
                             </div>
-                            
+
                             <div n:if="OPENVK_ROOT_CONF['openvk']['preferences']['commerce'] && $thisUser->getCoins() != 0" id="votesBalance">
                                 {tr("you_still_have_x_points", $thisUser->getCoins())|noescape}
                                 <br /><br />
-                                
+
                                 <a href="/settings?act=finance">{_top_up_your_account} &#xbb;</a>
                             </div>
-                            
+
                             <a n:if="OPENVK_ROOT_CONF['openvk']['preferences']['adPoster']['enable'] && $thisUser->getLeftMenuItemStatus('poster')" href="{php echo OPENVK_ROOT_CONF['openvk']['preferences']['adPoster']['link']}" >
                                 <img src="{php echo OPENVK_ROOT_CONF['openvk']['preferences']['adPoster']['src']}" alt="{php echo OPENVK_ROOT_CONF['openvk']['preferences']['adPoster']['caption']}" class="psa-poster" style="max-width: 100%; margin-top: 10px;" />
                             </a>
@@ -438,16 +438,16 @@
         {script "js/node_modules/leaflet-control-geocoder/dist/Control.Geocoder.js"}
         {css "js/node_modules/leaflet/dist/leaflet.css"}
         {css "js/node_modules/leaflet-control-geocoder/dist/Control.Geocoder.css"}
-        
+
         <script>bsdnHydrate();</script>
 
         <script n:if="OPENVK_ROOT_CONF['openvk']['telemetry']['plausible']['enable']" async defer data-domain="{php echo OPENVK_ROOT_CONF['openvk']['telemetry']['plausible']['domain']}" src="{php echo OPENVK_ROOT_CONF['openvk']['telemetry']['plausible']['server']}js/plausible.js"></script>
-        
+
         <script n:if="OPENVK_ROOT_CONF['openvk']['telemetry']['piwik']['enable']">
             {var $piwik = (object) OPENVK_ROOT_CONF['openvk']['telemetry']['piwik']}
-            
+
             //<![CDATA[
-            (function(window,document,dataLayerName,id){ 
+            (function(window,document,dataLayerName,id){
             window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({ start:(new Date).getTime(),event:"stg.start" });var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
             function stgCreateCookie(a,b,c){ var d="";if(c){ var e=new Date;e.setTime(e.getTime()+24*c*60*60*1e3),d=";expires="+e.toUTCString() }document.cookie=a+"="+b+d+";path=/" }
             var isStgDebug=(window.location.href.match("stg_debug")||document.cookie.match("stg_debug"))&&!window.location.href.match("stg_disable_debug");stgCreateCookie("stg_debug",isStgDebug?1:"",isStgDebug?14:-1);
@@ -457,7 +457,7 @@
              })(window,document,{$piwik->layer}, {$piwik->site});
             //]]>
         </script>
-        
+
         <script n:if="OPENVK_ROOT_CONF['openvk']['telemetry']['matomo']['enable']">
             {var $matomo = (object) OPENVK_ROOT_CONF['openvk']['telemetry']['matomo']}
             //<![CDATA[
@@ -500,4 +500,4 @@
     <!-- INCLUDING TEMPLATE FROM PARENTMODULE: {$parentModule} -->
 
     {include content}
-{/if} 
+{/if}

--- a/Web/static/css/main.css
+++ b/Web/static/css/main.css
@@ -2690,7 +2690,7 @@ a.poll-retract-vote {
     gap: 2px;
 }
 
-.post-buttons .vertical-attachment .vertical-attachment-content { 
+.post-buttons .vertical-attachment .vertical-attachment-content {
     /*max-height: 27px;*/
     padding: 3px 2px;
 }
@@ -2773,8 +2773,8 @@ a.poll-retract-vote {
 }
 
 .ovk-photo-view #ovk-photo-img {
-    max-width: 100%; 
-    max-height: 80vh; 
+    max-width: 100%;
+    max-height: 80vh;
     user-select: none;
 }
 
@@ -2904,8 +2904,8 @@ a.poll-retract-vote {
 
 #search_box input[type='search'] {
     height: 20px;
-    background: url('/assets/packages/static/openvk/img/search_icon.png') no-repeat 3px 4px; 
-    background-color: #fff; 
+    background: url('/assets/packages/static/openvk/img/search_icon.png') no-repeat 3px 4px;
+    background-color: #fff;
     padding-left: 18px !important;
     width: 120px;
 }
@@ -3572,8 +3572,8 @@ body.article .floating_sidebar, body.article .page_content {
 }
 
 .attachment_selector #attachment_insert .videosInsert .video_list .video-preview img {
-    max-width: 133px; 
-    height: 75px; 
+    max-width: 133px;
+    height: 75px;
     margin: auto;
 }
 
@@ -3779,7 +3779,7 @@ hr {
 
 .entity_vertical_list.mini .entity_vertical_list_item img {
     width: 35px;
-    height: 35px; 
+    height: 35px;
 }
 
 #gif_loader {
@@ -3824,12 +3824,12 @@ hr {
 }
 
 .media-page-wrapper .photo-page-wrapper-photo img {
-    max-width: 85%; 
+    max-width: 85%;
     max-height: 60vh;
 }
 
 .media-page-wrapper-details {
-    width: 100%; 
+    width: 100%;
     min-height: 100px;
     display: flex;
     justify-content: space-between;
@@ -3837,7 +3837,7 @@ hr {
 }
 
 .media-page-wrapper-comments {
-    min-height: 100px; 
+    min-height: 100px;
     width: 68%;
     margin-left: 3px;
 }
@@ -4096,8 +4096,8 @@ hr {
 
 #docs_page_wrapper .docs_page_search input[type="search"], .attachment_selector .attachment_search input {
     height: 23px;
-    background: url('/assets/packages/static/openvk/img/search_icon.png') no-repeat 3px 5px; 
-    background-color: #fff; 
+    background: url('/assets/packages/static/openvk/img/search_icon.png') no-repeat 3px 5px;
+    background-color: #fff;
     padding-left: 18px !important;
 }
 
@@ -4387,4 +4387,8 @@ hr {
 
 .sort_link_icon_asc {
     background-position: -11px -15px;
+}
+
+.hidden {
+    display: none !important;
 }

--- a/Web/static/js/scroll.js
+++ b/Web/static/js/scroll.js
@@ -1,35 +1,39 @@
-window.addEventListener("scroll", function(e) {
-    if(window.scrollY < 100) {
-        if(window.temp_y_scroll) {
-            u('.toTop').addClass('has_down')
-        }
-        document.body.classList.toggle("scrolled", false);
-    } else {
-        document.body.classList.toggle("scrolled", true);
-        u('.toTop').removeClass('has_down')
+window.addEventListener("scroll", function (e) {
+  if (window.scrollY < 100) {
+    if (window.temp_y_scroll) {
+      u(".toTop").addClass("has_down");
+      u(".toTop").removeClass("hidden");
     }
+
+    document.body.classList.toggle("scrolled", false);
+    u(".toTop").addClass("hidden");
+  } else {
+    document.body.classList.toggle("scrolled", true);
+    u(".toTop").removeClass("has_down");
+    u(".toTop").removeClass("hidden");
+  }
 });
 
-u(".toTop").on("click", function(e) {
-    const y_scroll = window.scrollY
-    const scroll_margin = 20
+u(".toTop").on("click", function (e) {
+  const y_scroll = window.scrollY;
+  const scroll_margin = 20;
 
-    if(y_scroll > 100) {
-        window.temp_y_scroll = y_scroll
-        window.scrollTo(0, scroll_margin)
-        window.scrollTo({
-            top: 0,
-            behavior: "smooth"
-        })
-    } else {
-        if(window.temp_y_scroll) {
-            window.scrollTo(0, window.temp_y_scroll - scroll_margin)
-            window.scrollTo({
-                top: window.temp_y_scroll,
-                behavior: "smooth"
-            })
-        }
+  if (y_scroll > 100) {
+    window.temp_y_scroll = y_scroll;
+    window.scrollTo(0, scroll_margin);
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  } else {
+    if (window.temp_y_scroll) {
+      window.scrollTo(0, window.temp_y_scroll - scroll_margin);
+      window.scrollTo({
+        top: window.temp_y_scroll,
+        behavior: "smooth",
+      });
     }
+  }
 
-    u(document).trigger('scroll')
-})
+  u(document).trigger("scroll");
+});


### PR DESCRIPTION
## Проблема
Элемент с классом `.toTop` изначально задаётся как `block` с фиксированной шириной и высотой. При увеличении масштаба страницы этот невидимый и бесполезный элемент **перекрывает левое меню с кнопками**, даже когда скроллинга страницы еще не было.

https://github.com/user-attachments/assets/7b23a129-d59c-4518-8cfc-e753018dda59

## Предлагаемое решение
Задаём для элемента с классом `.toTop` стиль `display: none;` **по умолчанию** и управляем его состоянием через JS.
Для удобства создан отдельный класс `.hidden`, чтобы проще менять это значение.

https://github.com/user-attachments/assets/36121559-c2b2-4df4-bbc8-c53bbe2fc0f9
