### PR TITLE
revert override and apply diag head padding style to main selector instead

### DIFF
--- a/Web/static/css/dialog.css
+++ b/Web/static/css/dialog.css
@@ -38,16 +38,12 @@ body.dimmed > .dimmer #clickable {
 }
 
 .ovk-diag-head {
-    padding: 10px 12px;
+    padding: 10px 12px 9px 12px;
     background-color: #757575;
     border-bottom: 1px solid #3e3e3e;
     color: #fff;
     font-weight: 900;
     font-size: 15px;
-}
-
-.ovk-msg-all .ovk-diag-head {
-    padding: 10px 12px 9px 12px;
 }
 
 .ovk-diag-body {


### PR DESCRIPTION
`.ovk-msg-all .ovk-diag-head` broke padding styles for some themes that modify the dialog box's header. This override seems unnecessary in general since we can just modify the original value