### PR TITLE
feat(reports): ability to exclude from global feed

### DIFF
--- a/Web/Models/Entities/Report.php
+++ b/Web/Models/Entities/Report.php
@@ -90,9 +90,15 @@ class Report extends RowModel
         }
     }
 
-    public function getAuthor(): RowModel
+    public function getAuthor(?bool $realPostAuthor = false): RowModel
     {
-        return $this->getContentObject()->getOwner();
+        if ($this->getContentType() == "user")
+            return $this->getContentObject();
+
+        if (!in_array($this->getContentType(), ["post", "comment", "note", "topic"]))
+            return $this->getContentObject()->getOwner();
+
+        return $this->getContentObject()->getOwner(!$realPostAuthor, $realPostAuthor);
     }
 
     public function getReportAuthor(): User
@@ -103,7 +109,7 @@ class Report extends RowModel
     public function banUser($initiator)
     {
         $reason = $this->getContentType() !== "user" ? ("**content-" . $this->getContentType() . "-" . $this->getContentId() . "**") : ("Подозрительная активность");
-        $this->getAuthor()->ban($reason, false, time() + $this->getAuthor()->getNewBanTime(), $initiator);
+        $this->getAuthor()->ban($reason, false, time() + $this->getAuthor(true)->getNewBanTime(), $initiator);
     }
 
     public function deleteContent()

--- a/Web/Presenters/ReportPresenter.php
+++ b/Web/Presenters/ReportPresenter.php
@@ -134,6 +134,25 @@ final class ReportPresenter extends OpenVKPresenter
         if (!$report || $report->isDeleted()) {
             $this->notFound();
         }
+        
+        if ($report->getContentType() === "user" && $this->postParam("excludeUserFromGlobalFeed")) {
+            $reportedUser = $report->getContentObject();
+            $reportedUser->setHide_Global_Feed(1);
+            $reportedUser->save();
+        }
+
+        if ($report->getContentType() !== "user" && $this->postParam("excludeAuthorFromGlobalFeed")) {
+            $reportedContentAuthor = $report->getAuthor(true);
+            $reportedContentAuthor->setHide_Global_Feed(1);
+            $reportedContentAuthor->save();
+        }
+
+        if (($report->getContentType() === "group" || $report->getAuthor()->getId() != $report->getAuthor(true)->getId()) && $this->postParam("excludeGroupFromGlobalFeed")) {
+            $reportedGroup = $report->getContentType() === "group" ? $report->getContentObject() : $report->getAuthor();
+            $reportedGroup->setHide_From_Global_Feed(1);
+            $reportedGroup->setEnforce_Hiding_From_Global_Feed(1);
+            $reportedGroup->save();
+        }
 
         if ($this->postParam("ban")) {
             $report->deleteContent();

--- a/Web/Presenters/templates/Report/View.xml
+++ b/Web/Presenters/templates/Report/View.xml
@@ -17,8 +17,19 @@
         <b>{_comment}:</b> {$report->getReason()}
     </p>
     {include "ViewContent.xml", type => $report->getContentType(), object => $report->getContentObject()}
-    <center>
     <form action="/admin/reportAction{$report->getId()}" method="post">
+        <div n:if="$report->getContentType() == 'user'">
+            <input type='checkbox' name='excludeUserFromGlobalFeed' id="excludeUserFromGlobalFeed"> {_report_force_exclude_user_from_global_feed|noescape}
+        </div>
+        <div n:if="$report->getContentType() != 'user'">
+            <input type='checkbox' name='excludeAuthorFromGlobalFeed' id="excludeAuthorFromGlobalFeed">
+            {_report_force_exclude_author_from_global_feed|noescape} (<a href="{$report->getAuthor(true)->getUrl()}" target="_blank">{$report->getAuthor(true)->getCanonicalName()}</a>)
+        </div>
+        <div n:if="$report->getAuthor()->getId() != $report->getAuthor(true)->getId() || $report->getContentType() == 'group'">
+            <input type='checkbox' name='excludeGroupFromGlobalFeed' id="excludeGroupFromGlobalFeed">
+            {_report_force_exclude_group_from_global_feed|noescape}
+            {if $report->getContentType() != 'group'}(<a href="{$report->getAuthor()->getUrl()}" target="_blank">{$report->getAuthor()->getCanonicalName()}</a>){/if}
+        </div>
         <center>
             <form n:if="$report->getContentType() != 'group'" action="/admin/reportAction{$report->getId()}" method="post">
                 <input type="hidden" name="hash" value="{$csrfToken}"/>

--- a/locales/en.strings
+++ b/locales/en.strings
@@ -2332,6 +2332,11 @@
 
 "nospam_prevention" = "This action will affect a lot of data. Are you sure you want to apply?";
 
+"report_force_exclude_author_from_global_feed" = "Exclude <b>content author</b> from global feed";
+"report_force_exclude_user_from_global_feed" = "Exclude <b>user</b> from global feed";
+"report_force_exclude_group_from_global_feed" = "Exclude <b>group</b> from global feed";
+
+
 /* RSS */
 
 "post_deact_in_general" = "Page deletion";

--- a/locales/ru.strings
+++ b/locales/ru.strings
@@ -2227,6 +2227,10 @@
 
 "nospam_prevention" = "Данное действие затронет множество данных. Вы действительно хотите применить?";
 
+"report_force_exclude_author_from_global_feed" = "Исключить <b>автора контента</b> из глобальной ленты";
+"report_force_exclude_user_from_global_feed" = "Исключить <b>пользователя</b> из глобальной ленты";
+"report_force_exclude_group_from_global_feed" = "Исключить <b>сообщество</b> из глобальной ленты";
+
 /* RSS */
 
 "post_deact_in_general" = "Удаление страницы";


### PR DESCRIPTION
Добавляет возможность исключать пользователя/сообщество из глобальной ленты по жалобе

Возможны 3 чекбокса:
1. Исключить автора контента из глобальной ленты
2. Исключить пользователя из глобальной ленты
3. Исключить сообщество из глобальной ленты

Чекбокс №1 появляется в любой жалобе, кроме жалоб на профили юзеров
Чекбокс №2 появляется в жалобах на профили юзеров
Чекбокс №3 появляется в жалобах на сообщество или на материалы, размещенные от его имени

№1 и №3 могут сочетаться (например, если жалоба будет на пост от имени сообщества, есть возможность исключить как само сообщество, так и настоящего автора поста)

<img width="1562" height="818" alt="image" src="https://github.com/user-attachments/assets/0cf2f4c0-bcfc-4ac0-a917-0730b55a90c8" />

Также исправлена ошибка, когда при блокировке пользователя, разместившего контент от сообщества, была попытка забанить группу

Resolves #1431
