### PR TITLE
feat(groups): wiki-pages

### DIFF
--- a/VKAPI/Handlers/Notes.php
+++ b/VKAPI/Handlers/Notes.php
@@ -9,7 +9,7 @@ use openvk\Web\Models\Repositories\Users as UsersRepo;
 use openvk\Web\Models\Repositories\Comments as CommentsRepo;
 use openvk\Web\Models\Repositories\Photos as PhotosRepo;
 use openvk\Web\Models\Repositories\Videos as VideosRepo;
-use openvk\Web\Models\Entities\{Note, Comment};
+use openvk\Web\Models\Entities\{User, Note, Comment};
 
 final class Notes extends VKAPIRequestHandler
 {
@@ -62,7 +62,7 @@ final class Notes extends VKAPIRequestHandler
             $this->fail(15, "Access denied");
         }
 
-        if (!$note->getOwner()->getPrivacyPermission('notes.read', $this->getUser())) {
+        if ($note->getOwner() instanceof User && !$note->getOwner()->getPrivacyPermission('notes.read', $this->getUser())) {
             $this->fail(15, "Access denied");
         }
 
@@ -92,7 +92,9 @@ final class Notes extends VKAPIRequestHandler
             $this->fail(15, "Access denied");
         }
 
-        if (!$note->canBeModifiedBy($this->getUser())) {
+        if ($note->getOwner() instanceof User && !$note->canBeModifiedBy($this->getUser())) {
+            $this->fail(15, "Access denied");
+        } elseif (!$note->getOwner()->canBeModifiedBy($this->getUser()) || $note->getOwner()->isWikiPagesDisabledEnforced()) {
             $this->fail(15, "Access denied");
         }
 
@@ -174,7 +176,8 @@ final class Notes extends VKAPIRequestHandler
             $this->fail(15, "Access denied");
         }
 
-        if (!$note->getOwner()->getPrivacyPermission('notes.read', $this->getUser())) {
+
+        if ($note->getOwner() instanceof User && !$note->getOwner()->getPrivacyPermission('notes.read', $this->getUser())) {
             $this->fail(15, "Access denied");
         }
 
@@ -203,7 +206,7 @@ final class Notes extends VKAPIRequestHandler
             $this->fail(15, "Access denied");
         }
 
-        if (!$note->getOwner()->getPrivacyPermission('notes.read', $this->getUser())) {
+        if ($note->getOwner() instanceof User && !$note->getOwner()->getPrivacyPermission('notes.read', $this->getUser())) {
             $this->fail(15, "Access denied");
         }
 

--- a/Web/Models/Entities/Club.php
+++ b/Web/Models/Entities/Club.php
@@ -7,7 +7,7 @@ namespace openvk\Web\Models\Entities;
 use openvk\Web\Util\DateTime;
 use openvk\Web\Models\RowModel;
 use openvk\Web\Models\Entities\{User, Manager};
-use openvk\Web\Models\Repositories\{Users, Clubs, Albums, Managers, Posts};
+use openvk\Web\Models\Repositories\{Users, Clubs, Albums, Managers, Notes, Posts};
 use Nette\Database\Table\{ActiveRow, GroupedSelection};
 use Chandler\Database\DatabaseConnection as DB;
 use Chandler\Security\User as ChandlerUser;
@@ -537,5 +537,39 @@ class Club extends RowModel
         }
 
         return $res;
+    }
+
+    public function canCreateNote(?User $user): bool
+    {
+        return $this->canBeModifiedBy($user);
+    }
+
+    public function getMainNoteId(): ?int
+    {
+        if ($this->isWikiPagesDisabledEnforced()) {
+            return null;
+        }
+
+        return $this->getRecord()->main_note_id;
+    }
+
+    public function getMainNote(): ?Note
+    {
+        return (new Notes())->get($this->getMainNoteId() ?? 0);
+    }
+
+    public function isMainNoteExpanded(): bool
+    {
+        return (bool) $this->getRecord()->is_main_note_expanded;
+    }
+
+    public function isMainNoteExpandedEnforced(): bool
+    {
+        return (bool) $this->getRecord()->enforce_main_note_expanded;
+    }
+
+    public function isWikiPagesDisabledEnforced(): bool
+    {
+        return (bool) $this->getRecord()->enforce_wiki_pages_disabled;
     }
 }

--- a/Web/Models/Repositories/Notes.php
+++ b/Web/Models/Repositories/Notes.php
@@ -7,6 +7,7 @@ namespace openvk\Web\Models\Repositories;
 use Chandler\Database\DatabaseConnection;
 use openvk\Web\Models\Entities\Note;
 use openvk\Web\Models\Entities\User;
+use openvk\Web\Models\Entities\Club;
 use Nette\Database\Table\ActiveRow;
 
 class Notes
@@ -38,6 +39,21 @@ class Notes
         }
     }
 
+    public function getClubNotes(Club $club, int $page = 1, ?int $perPage = null, string $sort = "DESC"): \Traversable
+    {
+        $perPage ??= OPENVK_DEFAULT_PER_PAGE;
+        foreach ($this->notes->where("owner", $club->getId() * -1)->where("deleted", 0)->order("created $sort")->page($page, $perPage) as $album) {
+            yield new Note($album);
+        }
+    }
+
+    public function getAllClubNotes(Club $club, string $sort = "DESC"): \Traversable
+    {
+        foreach ($this->notes->where("owner", $club->getId() * -1)->where("deleted", 0)->order("created $sort") as $album) {
+            yield new Note($album);
+        }
+    }
+
     public function getNoteById(int $owner, int $note): ?Note
     {
         $note = $this->notes->where(['owner' => $owner, 'virtual_id' => $note])->fetch();
@@ -51,5 +67,10 @@ class Notes
     public function getUserNotesCount(User $user): int
     {
         return sizeof($this->notes->where("owner", $user->getId())->where("deleted", 0));
+    }
+
+    public function getClubNotesCount(Club $club): int
+    {
+        return $this->notes->where("owner", $club->getId() * -1)->where("deleted", 0)->count('*');
     }
 }

--- a/Web/Presenters/AdminPresenter.php
+++ b/Web/Presenters/AdminPresenter.php
@@ -258,6 +258,8 @@ final class AdminPresenter extends OpenVKPresenter
                 $club->setVerified(empty($this->postParam("verify") ? 0 : 1));
                 $club->setHide_From_Global_Feed(empty($this->postParam("hide_from_global_feed") ? 0 : 1));
                 $club->setEnforce_Hiding_From_Global_Feed(empty($this->postParam("enforce_hiding_from_global_feed") ? 0 : 1));
+                $club->setEnforce_Main_Note_Expanded(empty($this->postParam("enforce_main_note_expanded") ? 0 : 1));
+                $club->setEnforce_Wiki_Pages_Disabled(empty($this->postParam("enforce_wiki_pages_disabled") ? 0 : 1));
                 $club->save();
                 break;
             case "ban":

--- a/Web/Presenters/CommentPresenter.php
+++ b/Web/Presenters/CommentPresenter.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace openvk\Web\Presenters;
 
-use openvk\Web\Models\Entities\{Comment, Notifications\MentionNotification, Photo, Video, User, Topic, Post};
+use openvk\Web\Models\Entities\{Comment, Club, Notifications\MentionNotification, Note, Photo, Video, User, Topic, Post};
 use openvk\Web\Models\Entities\Notifications\CommentNotification;
 use openvk\Web\Models\Repositories\{Comments, Clubs, Videos, Photos, Audios};
 use Nette\InvalidStateException as ISE;
@@ -81,6 +81,10 @@ final class CommentPresenter extends OpenVKPresenter
         }
 
         if ($entity instanceof Topic && $entity->isRestricted() && !$entity->getClub()->canBeModifiedBy($this->user->identity)) {
+            $this->flashFail("err", tr("error"), tr("forbidden"));
+        }
+
+        if ($entity instanceof Note && $entity->getOwner() instanceof Club) {
             $this->flashFail("err", tr("error"), tr("forbidden"));
         }
 

--- a/Web/Presenters/NotesPresenter.php
+++ b/Web/Presenters/NotesPresenter.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace openvk\Web\Presenters;
 
-use openvk\Web\Models\Repositories\{Users, Notes};
-use openvk\Web\Models\Entities\Note;
+use openvk\Web\Models\Repositories\{Clubs, Users, Notes};
+use openvk\Web\Models\Entities\{User, Note};
 
 final class NotesPresenter extends OpenVKPresenter
 {
@@ -21,31 +21,54 @@ final class NotesPresenter extends OpenVKPresenter
 
     public function renderList(int $owner): void
     {
-        $user = (new Users())->get($owner);
-        if (!$user) {
-            $this->notFound();
-        }
-        if (!$user->getPrivacyPermission('notes.read', $this->user->identity ?? null)) {
-            $this->flashFail("err", tr("forbidden"), tr("forbidden_comment"));
-        }
-
         $this->template->page  = (int) ($this->queryParam("p") ?? 1);
-        $this->template->notes = $this->notes->getUserNotes($user, $this->template->page);
-        $this->template->count = $this->notes->getUserNotesCount($user);
-        $this->template->owner = $user;
+
+        if ($owner > 0) {
+            $user = (new Users())->get($owner);
+
+            if (!$user) {
+                $this->notFound();
+            }
+            if (!$user->getPrivacyPermission('notes.read', $this->user->identity ?? null)) {
+                $this->flashFail("err", tr("forbidden"), tr("forbidden_comment"));
+            }
+
+            $this->template->notes = $this->notes->getUserNotes($user, $this->template->page);
+            $this->template->count = $this->notes->getUserNotesCount($user);
+            $this->template->owner = $user;
+        } else {
+            $club = (new Clubs())->get($owner * -1);
+
+            if (!$club || $club->isBanned() || is_null($this->user) || !$club->canBeModifiedBy($this->user->identity) || $club->isWikiPagesDisabledEnforced()) {
+                $this->notFound();
+            }
+
+            $this->template->notes = $this->notes->getClubNotes($club, $this->template->page);
+            $this->template->count = $this->notes->getClubNotesCount($club);
+            $this->template->owner = $club;
+            $this->template->canCreateNotesInThisGroup = $club->canCreateNote($this->user->identity);
+        }
     }
 
     public function renderView(int $owner, int $note_id): void
     {
         $note = $this->notes->getNoteById($owner, $note_id);
-        if (!$note || $note->getOwner()->getId() !== $owner || $note->isDeleted()) {
+        if (!$note || $note->isDeleted()) {
             $this->notFound();
         }
-        if (!$note->getOwner()->getPrivacyPermission('notes.read', $this->user->identity ?? null)) {
-            $this->flashFail("err", tr("forbidden"), tr("forbidden_comment"));
-        }
-        if (!$note->canBeViewedBy($this->user->identity)) {
-            $this->flashFail("err", tr("forbidden"), tr("forbidden_comment"));
+
+        if ($note->getOwner() instanceof User) {
+            if ($note->getOwner()->getId() !== $owner) {
+                $this->notFound();
+            }
+            if (!$note->getOwner()->getPrivacyPermission('notes.read', $this->user->identity ?? null)) {
+                $this->flashFail("err", tr("forbidden"), tr("forbidden_comment"));
+            }
+            if (!$note->canBeViewedBy($this->user->identity)) {
+                $this->flashFail("err", tr("forbidden"), tr("forbidden_comment"));
+            }
+        } elseif ($note->getOwner()->isBanned() || $note->getOwner()->isWikiPagesDisabledEnforced()) {
+            $this->flashFail("err", tr("error"), tr("forbidden"));
         }
 
         $this->template->cCount   = $note->getCommentsCount();
@@ -88,20 +111,38 @@ final class NotesPresenter extends OpenVKPresenter
             $this->notFound();
         }
 
+        $owner = $id;
+
+        $group_id = (int) $this->queryParam("gid");
+
+        if ($group_id) {
+            $group = (new Clubs())->get($group_id);
+            if (!$group || $group->isBanned()) {
+                $this->notFound();
+            }
+
+            if (!$group->canCreateNote($this->user->identity) || $group->isWikiPagesDisabledEnforced()) {
+                $this->flashFail("err", tr("error"), tr("forbidden"));
+            }
+
+            $owner = $group->getId() * -1;
+            $this->template->club = $group;
+        }
+
         if ($_SERVER["REQUEST_METHOD"] === "POST") {
             if (empty($this->postParam("name"))) {
                 $this->flashFail("err", tr("error"), tr("error_segmentation"));
             }
 
             $note = new Note();
-            $note->setOwner($this->user->id);
+            $note->setOwner($owner);
             $note->setCreated(time());
             $note->setName($this->postParam("name"));
             $note->setSource($this->postParam("html"));
             $note->setEdited(time());
             $note->save();
 
-            $this->redirect("/note" . $this->user->id . "_" . $note->getVirtualId());
+            $this->redirect("/note" . $owner . "_" . $note->getVirtualId());
         }
     }
 
@@ -112,12 +153,22 @@ final class NotesPresenter extends OpenVKPresenter
 
         $note = $this->notes->getNoteById($owner, $note_id);
 
-        if (!$note || $note->getOwner()->getId() !== $owner || $note->isDeleted()) {
+        if (!$note || $note->isDeleted()) {
             $this->notFound();
         }
-        if (is_null($this->user) || !$note->canBeModifiedBy($this->user->identity)) {
+
+        if ($note->getOwner() instanceof User) {
+            if ($note->getOwner()->getId() !== $owner) {
+                $this->notFound();
+            }
+
+            if (is_null($this->user) || !$note->canBeModifiedBy($this->user->identity)) {
+                $this->flashFail("err", tr("error_access_denied_short"), tr("error_access_denied"));
+            }
+        } elseif (is_null($this->user) || !$note->getOwner()->canBeModifiedBy($this->user->identity) || $note->getOwner()->isWikiPagesDisabledEnforced()) {
             $this->flashFail("err", tr("error_access_denied_short"), tr("error_access_denied"));
         }
+
         $this->template->note = $note;
 
         if ($_SERVER["REQUEST_METHOD"] === "POST") {
@@ -131,7 +182,7 @@ final class NotesPresenter extends OpenVKPresenter
             $note->setEdited(time());
             $note->save();
 
-            $this->redirect("/note" . $this->user->id . "_" . $note->getVirtualId());
+            $this->redirect("/note" . $note->getOwner()->getId() * ($note->getOwner() instanceof User ? 1 : -1) . "_" . $note->getVirtualId());
         }
     }
 
@@ -141,20 +192,33 @@ final class NotesPresenter extends OpenVKPresenter
         $this->willExecuteWriteAction();
         $this->assertNoCSRF();
 
-        $note = $this->notes->get($id);
-        if (!$note) {
+        $note = $this->notes->getNoteById($owner, $id);
+        if (!$note || $note->isDeleted()) {
             $this->notFound();
         }
-        if ($note->getOwner()->getId() . "_" . $note->getId() !== $owner . "_" . $id || $note->isDeleted()) {
-            $this->notFound();
-        }
-        if (is_null($this->user) || !$note->canBeModifiedBy($this->user->identity)) {
-            $this->flashFail("err", tr("error_access_denied_short"), tr("error_access_denied"));
+
+        $oid = $note->getOwner()->getId() * ($note->getOwner() instanceof User ? 1 : -1);
+
+        if ($oid > 0) {
+            if ($note->getOwner()->getId() . "_" . $note->getId() !== $owner . "_" . $id) {
+                $this->notFound();
+            }
+            if (is_null($this->user) || !$note->canBeModifiedBy($this->user->identity)) {
+                $this->flashFail("err", tr("error_access_denied_short"), tr("error_access_denied"));
+            }
+        } else {
+            if (is_null($this->user) || !$note->getOwner()->canBeModifiedBy($this->user->identity) || $note->getOwner()->isWikiPagesDisabledEnforced()) {
+                $this->flashFail("err", tr("error_access_denied_short"), tr("error_access_denied"));
+            }
+
+            if ($note->getId() === $note->getOwner()->getMainNoteId()) {
+                $this->flashFail("err", tr("error_access_denied_short"), tr("wiki_pages_cant_remove_main", "/club" . $note->getOwner()->getId() . "/notes"));
+            }
         }
 
         $name = $note->getName();
         $note->delete();
         $this->flash("succ", tr("note_is_deleted"), tr("note_x_is_now_deleted", $name));
-        $this->redirect("/notes" . $this->user->id);
+        $this->redirect("/notes" . $oid);
     }
 }

--- a/Web/Presenters/templates/Admin/Club.xml
+++ b/Web/Presenters/templates/Admin/Club.xml
@@ -69,6 +69,14 @@
                     <input class="toggle-large" type="checkbox" id="enforce_hiding_from_global_feed" name="enforce_hiding_from_global_feed" value="1" n:attr="checked => $club->isHidingFromGlobalFeedEnforced()" />
                     <label for="enforce_hiding_from_global_feed">{_admin_club_enforceexcludeglobalfeed}</label>
                 </div>
+                <div class="group">
+                    <input class="toggle-large" type="checkbox" id="enforce_main_note_expanded" name="enforce_main_note_expanded" value="1" n:attr="checked => $club->isMainNoteExpandedEnforced()" />
+                    <label for="enforce_main_note_expanded">{_admin_club_enforce_main_page_expanded}</label>
+                </div>
+                <div class="group">
+                    <input class="toggle-large" type="checkbox" id="enforce_wiki_pages_disabled" name="enforce_wiki_pages_disabled" value="1" n:attr="checked => $club->isWikiPagesDisabledEnforced()" />
+                    <label for="enforce_wiki_pages_disabled">{_admin_club_enforce_wiki_pages_disabled}</label>
+                </div>
                 <hr/>
                 <div class="buttons-container">
                     <div class="buttons">

--- a/Web/Presenters/templates/Group/Edit.xml
+++ b/Web/Presenters/templates/Group/Edit.xml
@@ -22,6 +22,11 @@
                 {_followers}
             </a>
         </div>
+        <div class="tab">
+            <a href="/club{$club->getId()}/notes">
+                {_wiki_pages}
+            </a>
+        </div>
     </div>
     
     <div class="container_gray">

--- a/Web/Presenters/templates/Group/EditBackdrop.xml
+++ b/Web/Presenters/templates/Group/EditBackdrop.xml
@@ -24,6 +24,11 @@
                 {_followers}
             </a>
         </div>
+        <div class="tab">
+            <a href="/club{$club->getId()}/notes">
+                {_wiki_pages}
+            </a>
+        </div>
     </div>
 
     <div class="container_gray">

--- a/Web/Presenters/templates/Group/Followers.xml
+++ b/Web/Presenters/templates/Group/Followers.xml
@@ -33,6 +33,11 @@
 				{_followers}
 			</a>
 		</div>
+        <div class="tab">
+            <a href="/club{$club->getId()}/notes">
+                {_wiki_pages}
+            </a>
+        </div>
 	{/if}
 {/block}
 

--- a/Web/Presenters/templates/Group/Notes.xml
+++ b/Web/Presenters/templates/Group/Notes.xml
@@ -1,0 +1,112 @@
+{extends "../@layout.xml"}
+{var $backdrops = $club->getBackDropPictureURLs()}
+
+{block title}{$club->getName()} | {_wiki_pages}{/block}
+
+{block header}
+<a href="{$club->getURL()}">{$club->getName()}</a> » {_wiki_pages}
+{/block}
+
+{block content}
+    <div class="tabs">
+        <div class="tab">
+            <a href="/club{$club->getId()}/edit">
+                {_main}
+            </a>
+        </div>
+        <div class="tab">
+            <a href="/club{$club->getId()}/backdrop">
+                {_backdrop_short}
+            </a>
+        </div>
+        <div class="tab">
+            <a href="/club{$club->getId()}/followers">
+                {_followers}
+            </a>
+        </div>
+        <div id="activetabs" class="tab">
+            <a id="act_tab_a" href="/club{$club->getId()}/notes">
+                {_wiki_pages}
+            </a>
+        </div>
+    </div>
+
+    <div class="container_gray">
+        <h4>{_menu_settings}</h4>
+        <form method="POST" enctype="multipart/form-data">
+            <table cellspacing="7" cellpadding="0" width="60%" border="0" align="center">
+                <tbody>
+                    <tr>
+                        <td width="120" valign="top">
+                            <span class="nobold">{_main_wiki_page}: </span>
+                        </td>
+                        <td>
+                            <select class="select" name="nid">
+                                <option value="">{_relationship_0}</option>
+                                <option n:foreach="$notes as $note" value="{$note->getId()}" {if $club->getMainNoteId() === $note->getId()}selected{/if}>
+                                    {$note->getName()}
+                                </option>
+                            </select>
+                            <div class="group">
+                                <input class="toggle-large" type="checkbox" id="expanded" name="expanded" value="1" n:attr="checked => $club->isMainNoteExpanded(), disabled => $club->isMainNoteExpandedEnforced()" />
+                                <label for="expanded">{_wiki_page_expanded_by_default}</label>
+                            </div>
+                        </td>
+                    </tr>
+                    
+
+                    <tr>
+                        <td>
+                            
+                        </td>
+                        <td>
+                            <input type="hidden" name="hash" value="{$csrfToken}" />
+                            <input type="submit" value="{_save}" class="button" />
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        </form>
+        <div style="padding-bottom: 0px; padding-top: 0;" class="summaryBar">
+            <div class="summary">
+                    {_wiki_pages}
+                    <span>
+                        &nbsp;|&nbsp;
+                        <a href="/notes/create?gid={$club->getId()}">{_create_note}</a>
+                    </span>
+            </div>
+        </div>
+        {if $count > 10}
+            <br />
+            <a style="margin-left: 10px;" href="/notes-{$club->getId()}"><b>{tr("wiki_pages_show_all", $count)} »</b></a>
+        {elseif $count == 0}
+            <br />
+            {include ../components/nothing.xml}
+        {/if}
+        <br /><br />
+        <table n:foreach="array_slice($notes, 0, 10) as $note" border="0" style="font-size: 11px; width: 610px;" class="post">
+            <tbody>
+                <tr>
+                    <td width="54" valign="top">
+                        <center>
+                            <img src="/assets/packages/static/openvk/img/note_icon.png" style="margin-top: 17px;">
+                        </center>
+                    </td>
+                    <td width="345" valign="top">
+                        <div class="post-author">
+                            <a href="/note-{$club->getId()}_{$note->getVirtualId()}">
+                                <b>{$note->getName()}</b>
+                            </a>
+                        </div>
+                        <div class="post-content" style="padding: 4px; font-size: 11px;">
+                            <div class="byline">
+                                {$note->getPublicationTime()}
+                                <span n:if="$note->getEditTime() > $note->getPublicationTime()">({_edited} {$note->getEditTime()})</span>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+{/block}

--- a/Web/Presenters/templates/Group/View.xml
+++ b/Web/Presenters/templates/Group/View.xml
@@ -43,6 +43,43 @@
             </tbody>
         </table>
     </div>
+
+    {if !(!$club->getMainNote() || $club->getMainNote()->isDeleted() || $club->isWikiPagesDisabledEnforced())}
+        <div n:attr="class => $club->isMainNoteExpanded() ? 'content_title_expanded' : 'content_title_unexpanded'" onclick="hidePanel(this);">
+            {_materials}
+        </div>
+        
+        <div id="userContent" style="margin-left: 6px; width: 390px; {if !$club->isMainNoteExpanded()}display: none;{/if}">
+            {$club->getMainNote()->getText()|noescape}
+        </div>
+
+        <style>
+            #userContent img {
+                max-width: 245pt;
+                max-height: 200pt;
+            }
+
+            #userContent blockquote {
+                background-color: #f3f3f3;
+                border-bottom: 5px solid #969696;
+                padding: 1;
+            }
+
+            #userContent cite {
+                margin-top: 1em;
+                display: block;
+            }
+
+            #userContent cite::before {
+                content: "— ";
+            }
+
+            #userContent .underline {
+                text-decoration: underline;
+            }
+        </style>
+    {/if}
+
     <div n:if="$thisUser && $club->getFollowersCount() > 0">
         {var $followersCount = $club->getFollowersCount()}
         

--- a/Web/Presenters/templates/Notes/Create.xml
+++ b/Web/Presenters/templates/Notes/Create.xml
@@ -3,6 +3,10 @@
 {block title}{_create_note}{/block}
 
 {block header}
+    {if isset($club)}
+        <a href="{$club->getURL()}">{$club->getCanonicalName()}</a>
+        »
+    {/if}
     {_create_note}
 {/block}
 

--- a/Web/Presenters/templates/Notes/Edit.xml
+++ b/Web/Presenters/templates/Notes/Edit.xml
@@ -6,9 +6,9 @@
     {var $author = $note->getOwner()}
     <a href="{$author->getURL()}">{$author->getCanonicalName()}</a>
     »
-    <a href="/notes{$author->getId()}">{_notes}</a>
+    <a href="/notes{$author->getId() * ($author instanceof openvk\Web\Models\Entities\User ? 1 : -1)}">{_notes}</a>
     »
-    <a href="/note{$author->getId()}_{$note->getVirtualId()}">{$note->getName()}</a>
+    <a href="/note{$note->getPrettyId()}">{$note->getName()}</a>
 {/block}
 
 {block content}
@@ -23,7 +23,7 @@
         <input type="hidden" name="hash" value="{$csrfToken}" />
         <button class="button">{_save}</button>
         &nbsp;
-        <a href="/note{$note->getOwner()->getId()}_{$note->getVirtualId()}" class="button">{_cancel}</a>
+        <a href="/note{$note->getPrettyId()}" class="button">{_cancel}</a>
     </form>
     
     {script "js/node_modules/monaco-editor/min/vs/loader.js"}

--- a/Web/Presenters/templates/Notes/List.xml
+++ b/Web/Presenters/templates/Notes/List.xml
@@ -18,9 +18,9 @@
     <div style="padding-bottom: 0px; padding-top: 0;" class="summaryBar">
         <div class="summary">
                 {tr("notes_list", $count)}
-                <span n:if="isset($thisUser) && $thisUser->getId() == $owner->getId()">
+                <span n:if="(isset($thisUser) && $thisUser->getId() == $owner->getId()) || $canCreateNotesInThisGroup">
                     &nbsp;|&nbsp;
-                    <a href="/notes/create" rel='nofollow'>{_create_note}</a>
+                    <a href="/notes/create{if $owner instanceof \openvk\Web\Models\Entities\Club}?gid={$owner->getId()}{/if}" rel='nofollow'>{_create_note}</a>
                 </span>
         </div>
     </div>
@@ -87,19 +87,20 @@
                 </div>
                 <div class="note_footer" style="margin: 10px 0 0;">
                     <div class="comments_count">
-                        <a href="/note{$dat->getPrettyId()}">
-
-                            {if $dat->getCommentsCount() > 0}
-                                {_comments} ({$dat->getCommentsCount()})
-                            {else}
-                                {_no_comments}
-                            {/if}
-                            
-                        </a>
-                        <span n:if="isset($thisUser) && $thisUser->getId() === $dat->getOwner()->getId()">&nbsp;|&nbsp;
-                            <a id="_noteDelete" href="/note{$dat->getOwner()->getId()}_{$dat->getId()}/delete">{_delete}</a>
+                        {if !($owner instanceof openvk\Web\Models\Entities\Club)}
+                            <a href="/note{$dat->getPrettyId()}">
+                                {if $dat->getCommentsCount() > 0}
+                                    {_comments} ({$dat->getCommentsCount()})
+                                {else}
+                                    {_no_comments}
+                                {/if}                            
+                            </a>
                             &nbsp;|&nbsp;
-                            <a href="/note{$dat->getOwner()->getId()}_{$dat->getVirtualId()}/edit" rel='nofollow'>{_edit}</a>
+                        {/if}
+                        <span n:if="(isset($thisUser) && $thisUser->getId() === $dat->getOwner()->getId()) || ($owner instanceof openvk\Web\Models\Entities\Club && $owner->canBeModifiedBy($thisUser))">
+                            <a id="_noteDelete" href="/note{$dat->getPrettyId()}/delete">{_delete}</a>
+                            &nbsp;|&nbsp;
+                            <a href="/note{$dat->getPrettyId()}/edit" rel='nofollow'>{_edit}</a>
                         </span>
                     </div>
                 </div>

--- a/Web/Presenters/templates/Notes/View.xml
+++ b/Web/Presenters/templates/Notes/View.xml
@@ -4,15 +4,18 @@
 
 {block header}
     {var $author = $note->getOwner()}
-    <a href="{$author->getURL()}">{$author->getCanonicalName()}</a>
-    »
-    <a href="/notes{$author->getId()}">{_notes}</a>
-    »
+    {if $author instanceof openvk\Web\Models\Entities\User || (isset($thisUser) && $author->canBeModifiedBy($thisUser))}
+        <a href="{$author->getURL()}">{$author->getCanonicalName()}</a>
+        »
+        <a href="/notes{$author instanceof openvk\Web\Models\Entities\Club ? ($author->getId() * -1) : $author->getId()}">{_notes}</a>
+        »
+    {/if}
     {$note->getName()}
 {/block}
 
 {block content}
     {var $author = $note->getOwner()}
+    {var $isAuthorClub = $author instanceof openvk\Web\Models\Entities\Club}
     <style>
         #userContent img {
             max-width: 245pt;
@@ -40,7 +43,7 @@
     </style>
 
     <article id="userContent" style="margin: 10px 10px 0;">
-        <div class="note_header">
+        <div class="note_header" n:if="!$isAuthorClub">
             <div class="note_title">
                 <div class="note_title">
                     <a>{$note->getName()}</a>
@@ -56,27 +59,35 @@
         </div>
     </article>
 
-    <div class="note_footer" style="margin: 10px 10px 0;">
-        <div class="comments_count">
-            {if sizeof($comments) > 0}
-                {_comments} ({$note->getCommentsCount()})
-            {else}
-                {_no_comments}
-            {/if}
-            <span n:if="isset($thisUser) && $thisUser->getId() === $note->getOwner()->getId()">&nbsp;|&nbsp;
-                <a id="_noteDelete" href="/note{$note->getOwner()->getId()}_{$note->getId()}/delete">{_delete}</a>
-                &nbsp;|&nbsp;
-                <a href="/note{$note->getOwner()->getId()}_{$note->getVirtualId()}/edit" rel='nofollow'>{_edit}</a>
-            </span>
+    {if !$isAuthorClub}
+        <div class="note_footer" style="margin: 10px 10px 0;">
+            <div class="comments_count">
+                {if sizeof($comments) > 0}
+                    {_comments} ({$note->getCommentsCount()})
+                {else}
+                    {_no_comments}
+                {/if}
+                <span n:if="isset($thisUser) && $thisUser->getId() === $note->getOwner()->getId()">&nbsp;|&nbsp;
+                    <a id="_noteDelete" href="/note{$note->getOwner()->getId()}_{$note->getId()}/delete">{_delete}</a>
+                    &nbsp;|&nbsp;
+                    <a href="/note{$note->getOwner()->getId()}_{$note->getVirtualId()}/edit" rel='nofollow'>{_edit}</a>
+                </span>
+            </div>
         </div>
-    </div>
-    <div style="margin: 6px 10px 10px;border-top: 1px solid #ddd;">
-        {include "../components/comments.xml",
-            comments => $comments,
-            count => $cCount,
-            page => $cPage,
-            model => "notes",
-            parent => $note,
-            showTitle => false}
-    </div>
+        <div style="margin: 6px 10px 10px;border-top: 1px solid #ddd;">
+            {include "../components/comments.xml",
+                comments => $comments,
+                count => $cCount,
+                page => $cPage,
+                model => "notes",
+                parent => $note,
+                showTitle => false}
+        </div>
+    {elseif isset($thisUser) && $note->getOwner()->canBeModifiedBy($thisUser)}
+       <span>
+            <a id="_noteDelete" href="/note{$note->getOwner()->getId() * -1}_{$note->getId()}/delete">{_delete}</a>
+            &nbsp;|&nbsp;
+            <a href="/note{$note->getOwner()->getId() * -1}_{$note->getVirtualId()}/edit" rel='nofollow'>{_edit}</a>
+        </span>
+    {/if}
 {/block}

--- a/Web/routes.yml
+++ b/Web/routes.yml
@@ -239,6 +239,8 @@ routes:
       handler: "Group->statistics"
     - url: "/club{num}/followers"
       handler: "Group->followers"
+    - url: "/club{num}/notes"
+      handler: "Group->notes"
     - url: "/club{num}/followers/{num}"
       handler: "Group->admin"
     - url: "/club{num}/setAdmin"

--- a/install/sqls/00060-groups-wiki-pages.sql
+++ b/install/sqls/00060-groups-wiki-pages.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `groups`
+ADD `main_note_id` BIGINT UNSIGNED NULL DEFAULT NULL AFTER `audio_broadcast_enabled`,
+ADD `is_main_note_expanded` TINYINT(1) NOT NULL DEFAULT '0' AFTER `main_note_id`,
+ADD `enforce_main_note_expanded` TINYINT(1) NOT NULL DEFAULT '0' AFTER `is_main_note_expanded`,
+ADD `enforce_wiki_pages_disabled` TINYINT(1) NOT NULL DEFAULT '0' AFTER `enforce_main_note_expanded`;

--- a/locales/en.strings
+++ b/locales/en.strings
@@ -489,6 +489,14 @@
 
 "group_banned" = "Unfortunately, we had to block the <b>$1</b> group.";
 
+"wiki_pages" = "Wiki pages";
+"main_wiki_page" = "Main wiki page";
+"wiki_page_expanded_by_default" = "Expanded by default";
+"wiki_pages_show_all" = "Show all $1 pcs.";
+"wiki_pages_banned_by_instance_admins" = "Your group has been banned from using wiki pages. You can ask about the reason <a href='/support'>in Support</a>";
+"wiki_pages_cant_remove_main" = "You cannot delete the main wiki page in the group. You can change or remove it <a href='$1'>in the group settings</a>";
+"materials" = "Materials";
+
 /* Albums */
 
 "create" = "Create";
@@ -1725,6 +1733,8 @@
 "admin_club_search" = "Search for groups";
 "admin_club_excludeglobalfeed" = "Do not display posts in the global feed";
 "admin_club_enforceexcludeglobalfeed" = "Disallow group staff from changing global feed status";
+"admin_club_enforce_main_page_expanded" = "Disallow group staff from changing the display of the main wiki page";
+"admin_club_enforce_wiki_pages_disabled" = "Disallow wiki pages";
 
 "admin_services" = "Paid services";
 "admin_newgift" = "New gift";

--- a/locales/ru.strings
+++ b/locales/ru.strings
@@ -473,6 +473,14 @@
 "error_suggestions_open" = "У этой группы открытая стена.";
 "error_suggestions_access" = "Просматривать все предложенные записи могут только администраторы группы.";
 
+"wiki_pages" = "Вики-страницы";
+"main_wiki_page" = "Главная вики-страница";
+"wiki_page_expanded_by_default" = "Раскрывать по умолчанию";
+"wiki_pages_show_all" = "Смотреть все $1 шт.";
+"wiki_pages_banned_by_instance_admins" = "Вашему сообществу было запрещено использовать вики-страницы. Узнать причину можно <a href='/support'>в Поддержке</a>";
+"wiki_pages_cant_remove_main" = "Нельзя удалить главную вики-страницу в сообществе. Сменить или убрать её можно <a href='$1'>в настройках группы</a>";
+"materials" = "Материалы";
+
 /* Albums */
 
 "create" = "Создать";
@@ -1622,6 +1630,8 @@
 "admin_club_search" = "Поиск групп";
 "admin_club_excludeglobalfeed" = "Не отображать записи в глобальной ленте";
 "admin_club_enforceexcludeglobalfeed" = "Запретить руководству группы изменять отображение в глобальной ленте";
+"admin_club_enforce_main_page_expanded" = " Запретить руководству группы изменять отображение главной вики-страницы";
+"admin_club_enforce_wiki_pages_disabled" = "Запретить вики-страницы";
 "admin_services" = "Платные услуги";
 "admin_newgift" = "Новый подарок";
 "admin_price" = "Цена";


### PR DESCRIPTION
Добавляет сообществам вики-страницы (основанные на существующей инфраструктуре заметок). У них есть несколько особенностей:
* Комментарии к ним отключены
* Список заметок группы доступен только её админам, как и их создание/редактирование/удаление
<img width="938" height="564" alt="image" src="https://github.com/user-attachments/assets/661bac18-5574-4487-a521-33d93acb029d" />

Для группы можно выбрать одну главную вики-страницу, которая будет отображаться в сообществе после блока с основной информацией. Её можно сделать по умолчанию раскрытой, или наоборот, свернутой
<img width="941" height="640" alt="image" src="https://github.com/user-attachments/assets/3a4fe0f8-52f0-4f03-b631-a5c31f1e26fb" />

Админы инстанса могут запретить менять этот параметр, или запретить группе создавать вики-страницы в целом, тогда уже существующие перестанут отображаться, а при попытке открытия раздела будет ошибка
<img width="846" height="84" alt="image" src="https://github.com/user-attachments/assets/61878ac8-15f4-4eb2-be75-e57ec3fbfa51" />

