### PR TITLE
fix: add null and empty checks for popular_groups in aboutInstance

### DIFF
--- a/VKAPI/Handlers/Ovk.php
+++ b/VKAPI/Handlers/Ovk.php
@@ -57,10 +57,18 @@ final class Ovk extends VKAPIRequestHandler
         }
 
         if (in_array("popular_groups", $fields)) {
-            $popularClubs  = iterator_to_array((new ClubsRepo())->getPopularClubs());
-            $clubsResponse = (new Groups($this->getUser()))->getById(implode(',', array_map(function ($entry) {
-                return $entry->club->getId();
-            }, $popularClubs)), "", "members_count, " . $group_fields);
+            $popularClubsRaw = (new ClubsRepo())->getPopularClubs();
+            $popularClubs = $popularClubsRaw !== null ? iterator_to_array($popularClubsRaw) : [];
+
+            $clubsResponse = [];
+
+            if (!empty($popularClubs)) {
+                $ids = implode(',', array_map(function ($entry) {
+                    return $entry->club->getId();
+                }, $popularClubs));
+
+                $clubsResponse = (new Groups($this->getUser()))->getById($ids, "", "members_count, " . $group_fields);
+            }
 
             $response->popular_groups = (object) [
                 "count" => sizeof($popularClubs),


### PR DESCRIPTION
Запрос выдавал 500 при обращении к методу `ovk.aboutInstance`, потому что результат `getPopularClubs()` не обрабатывался на null и сразу запускался `iterator_to_array()`.

В этом PR сделал дополнительные проверки, чтобы при обращении к методу запрос не падал:
- Добавлена проверка на null, чтобы iterator_to_array() не выбивал ошибку.
- Добавлена проверка на пустой массив перед вызовом `getById()`, чтобы не летела ошибка `group_ids is undefined` из-за пустой строки.

Теперь если популярных групп нет (или как сейчас это закомментировано), сервер просто отдает пустой массив вместо ошибки 500.

<img width="1906" height="1016" alt="изображение" src="https://github.com/user-attachments/assets/099d130d-c88b-47f9-9dfa-a83b52089eda" />
