### PR TITLE
fix(api): Add null check for friend_status in Users

### DIFF
--- a/VKAPI/Handlers/Users.php
+++ b/VKAPI/Handlers/Users.php
@@ -125,11 +125,13 @@ final class Users extends VKAPIRequestHandler
                                 }
                                 break;
                             case "friend_status":
-                                switch ($usr->getSubscriptionStatus($authuser)) {
+                                $friendStatus = $authuser ? $usr->getSubscriptionStatus($authuser) : 0;
+
+                                switch ($friendStatus) {
                                     case 3:
                                         # NOTICE falling through
                                     case 0:
-                                        $response[$i]->friend_status = $usr->getSubscriptionStatus($authuser);
+                                        $response[$i]->friend_status = $friendStatus;
                                         break;
                                     case 1:
                                         $response[$i]->friend_status = 2;


### PR DESCRIPTION
Этот PR добавляет проверку на `null` для `$usr->getSubscriptionStatus($authuser)`, чтобы избежать падения запроса и ошибки 500, если `$authuser` равен `null`. 
В случае `null` - `friend_status` устанавливается в `0` по умолчанию.