### PR TITLE
security: sanitize getFullName() output to prevent XSS

### DIFF
--- a/Web/Models/Entities/User.php
+++ b/Web/Models/Entities/User.php
@@ -209,7 +209,9 @@ class User extends RowModel
             $pseudo = " ($pseudo) ";
         }
 
-        return $this->getFirstName() . $pseudo . $this->getLastName();
+        $fullName = $this->getFirstName() . $pseudo . $this->getLastName();
+
+        return strip_tags($fullName);
     }
 
     public function getMorphedName(string $case = "genitive", bool $fullName = true, bool $startWithLastName = true): string


### PR DESCRIPTION
Этот PR исправляет XSS уязвимость в процессе регистрации. 
Если в имени или никнейме пользователя вставлен вредоносный payload, он может выполниться при использовании реферальной ссылки для регистрации. 

Проблема возникает из-за использования фильтра `|noescape` в шаблоне `Web/Presenters/templates/Auth/Register.xml`, который выводит голый HTML. 

Фикс заключается в том, что результат в `Web/Models/Entities/User.php` теперь выводится только после санитайза с помощью `strip_tags()`, удаляя любые html теги и js код перед выводом.

### Демонстрация уязвимости на локальном инстансе
<img width="1280" height="766" alt="изображение" src="https://github.com/user-attachments/assets/9620d874-2bae-4e73-af9c-3863f4a1ea95" />
