### PR TITLE
fix(interface, settings): opening new tab on ctrl+lmb, js settings now loading properly

### DIFF
--- a/Web/static/js/al_feed.js
+++ b/Web/static/js/al_feed.js
@@ -325,40 +325,6 @@ u(document).on('change', `input[data-act='localstorage_item']`, (e) => {
     localStorage.setItem(e.target.name, Number(e.target.checked))
 })
 
-function openJsSettings() {
-    const CURRENT_AUTO_SCROLL = Number(localStorage.getItem('ux.auto_scroll') ?? 1)
-    const CURRENT_DISABLE_AJAX = Number(localStorage.getItem('ux.disable_ajax_routing') ?? 0)
-
-    u("#_js_settings").append(`
-        <tr>
-            <td width="120" valign="top">
-                <span class="nobold">
-                    <input type='checkbox' data-act='localstorage_item' data-inverse="1" name='ux.disable_ajax_routing' id="ux.disable_ajax_routing" ${CURRENT_DISABLE_AJAX == 0 ? 'checked' : ''}>
-                </span>
-            </td>
-            <td>
-                <label for='ux.disable_ajax_routing'>${tr('ajax_routing')}</label>
-            </td>
-        </tr>
-        <tr>
-            <td width="120" valign="top">
-                <span class="nobold">
-                    <input type='checkbox' data-act='localstorage_item' name='ux.auto_scroll' id="ux.auto_scroll" ${CURRENT_AUTO_SCROLL == 1 ? 'checked' : ''}>
-                </span>
-            </td>
-            <td>
-                <label for='ux.auto_scroll'>${tr('auto_scroll')}</label>
-            </td>
-        </tr>    
-        <tr>
-            <td width="120" valign="top"></td>
-            <td>
-                <a href="javascript:openPluginSettings()">${tr('ui_settings_window')}</a>
-            </td>
-        </tr>  
-    `)
-}
-
 // i hate it. Why there is >5 report functions ????????????
 function reportPost(postId) {
             uReportMsgTxt  = tr("going_to_report_post");

--- a/Web/static/js/openvk.cls.js
+++ b/Web/static/js/openvk.cls.js
@@ -257,6 +257,40 @@ function showIncreaseRatingDialog(coinsCount, userUrl, hash) {
     };
 }
 
+function openJsSettings() {
+    const CURRENT_AUTO_SCROLL = Number(localStorage.getItem('ux.auto_scroll') ?? 1)
+    const CURRENT_DISABLE_AJAX = Number(localStorage.getItem('ux.disable_ajax_routing') ?? 0)
+
+    u("#_js_settings").append(`
+        <tr>
+            <td width="120" valign="top">
+                <span class="nobold">
+                    <input type='checkbox' data-act='localstorage_item' data-inverse="1" name='ux.disable_ajax_routing' id="ux.disable_ajax_routing" ${CURRENT_DISABLE_AJAX == 0 ? 'checked' : ''}>
+                </span>
+            </td>
+            <td>
+                <label for='ux.disable_ajax_routing'>${tr('ajax_routing')}</label>
+            </td>
+        </tr>
+        <tr>
+            <td width="120" valign="top">
+                <span class="nobold">
+                    <input type='checkbox' data-act='localstorage_item' name='ux.auto_scroll' id="ux.auto_scroll" ${CURRENT_AUTO_SCROLL == 1 ? 'checked' : ''}>
+                </span>
+            </td>
+            <td>
+                <label for='ux.auto_scroll'>${tr('auto_scroll')}</label>
+            </td>
+        </tr>    
+        <tr>
+            <td width="120" valign="top"></td>
+            <td>
+                <a href="javascript:openPluginSettings()">${tr('ui_settings_window')}</a>
+            </td>
+        </tr>  
+    `)
+}
+
 let lastScrollTop = 0;
 $(document).on("scroll", () => {
     const currentScrollTop = $(document).scrollTop();

--- a/Web/static/js/router.js
+++ b/Web/static/js/router.js
@@ -305,7 +305,7 @@ u(document).on('click', 'a', async (e) => {
         return
     }
 
-    if(target.attr('target') == '_blank') {
+    if(target.attr('target') == '_blank' || e.ctrlKey || e.metaKey) {
         console.log('AJAX | Skipping because its _blank.')
         return
     }


### PR DESCRIPTION
При нажатии на ссылку с зажатым ctrl (cmd на маках), она теперь открывается в новой вкладке, как и должна это делать.

В процессе обнаружился ещё баг загрузки настроек js. В настройках внешнего вида настройки js подгружаются отдельной функцией openJsSettings(), которая определена в al_feed.js. Иногда этот скрипт не успевает прогрузиться, так как загружается в самом конце страницы, и настройки js не появляются. Поэтому я переместил эту функцию в openvk.cls.js