### PR TITLE
fix(locale-engine): correct comments removing

### DIFF
--- a/Web/Util/Localizator.php
+++ b/Web/Util/Localizator.php
@@ -39,7 +39,7 @@ class Localizator
         }
 
         $string = file_get_contents($file);
-        $string = preg_replace("%^\/\*.*\*\/\r?$%m", "", $string); #Remove comments
+        $string = preg_replace("%(?<!\")\/\*.*\*\/?%m", "", $string); #Remove comments
         $array  = [];
 
         foreach (preg_split("%;[\\r\\n]++%", $string) as $statement) {


### PR DESCRIPTION
fixes #1500

previously it removed comments only it it fill whole line like this:
```
/* i'm a comment */
```
if it was on same line as locale string, the string is just ignored:
```
"audios_one" = "One audio" /* this sucks balls */
```