### PR TITLE
fix(api): Correct album_id in photos.getWallUploadServer

### DIFF
--- a/VKAPI/Handlers/Photos.php
+++ b/VKAPI/Handlers/Photos.php
@@ -122,9 +122,11 @@ final class Photos extends VKAPIRequestHandler
             $album = (new Albums())->getUserWallAlbum($this->getUser());
         }
 
+        $albumId = $album ? $album->getId() : null;
+
         return (object) [
             "upload_url" => $this->getPhotoUploadUrl("photo", $group_id ?? 0),
-            "album_id"   => $album,
+            "album_id"   => $albumId,
             "user_id"    => $this->getUser()->getId(),
         ];
     }


### PR DESCRIPTION
Этот PR исправляет некорректное возвращение album_id методом photos.getWallUploadServer. Ранее возвращался пустой объект (без указания group_id). Сейчас оно как и в оригинальном VK API возвращает id.
<img width="771" height="877" alt="image" src="https://github.com/user-attachments/assets/b13b6532-9ca4-407f-98a8-fb1601f4cb99" />
