### PR TITLE
плейлисты к аудио

### DIFF
--- a/Web/Models/Entities/Audio.php
+++ b/Web/Models/Entities/Audio.php
@@ -450,6 +450,11 @@ class Audio extends Media
         $this->stateChanges("playlist_id", $album->getId());
     }
 
+    function setAlbumId(int $album): void 
+    {
+        $this->stateChanges("playlist_id", $album);
+    }
+
     function getAlbum(): ?Playlist
     {
         $playlist_id = $this->getRecord()->playlist_id;
@@ -464,6 +469,11 @@ class Audio extends Media
         }
 
         return $album;
+    }
+
+    function getAlbumId(): ?int
+    {
+        return $this->getRecord()->playlist_id;
     }
 
     public function setOwner(int $oid): void

--- a/Web/Models/Entities/Audio.php
+++ b/Web/Models/Entities/Audio.php
@@ -445,12 +445,12 @@ class Audio extends Media
         return $obj;
     }
 
-    public function setAlbum(Playlist $album): void 
+    public function setAlbum(Playlist $album): void
     {
         $this->stateChanges("playlist_id", $album->getId());
     }
 
-    public function setAlbumId(int $album): void 
+    public function setAlbumId(int $album): void
     {
         $this->stateChanges("playlist_id", $album);
     }

--- a/Web/Models/Entities/Audio.php
+++ b/Web/Models/Entities/Audio.php
@@ -445,17 +445,17 @@ class Audio extends Media
         return $obj;
     }
 
-    function setAlbum(Playlist $album): void 
+    public function setAlbum(Playlist $album): void 
     {
         $this->stateChanges("playlist_id", $album->getId());
     }
 
-    function setAlbumId(int $album): void 
+    public function setAlbumId(int $album): void 
     {
         $this->stateChanges("playlist_id", $album);
     }
 
-    function getAlbum(): ?Playlist
+    public function getAlbum(): ?Playlist
     {
         $playlist_id = $this->getRecord()->playlist_id;
         if (!$playlist_id) {
@@ -471,7 +471,7 @@ class Audio extends Media
         return $album;
     }
 
-    function getAlbumId(): ?int
+    public function getAlbumId(): ?int
     {
         return $this->getRecord()->playlist_id;
     }

--- a/Web/Models/Entities/Audio.php
+++ b/Web/Models/Entities/Audio.php
@@ -7,6 +7,7 @@ namespace openvk\Web\Models\Entities;
 use Chandler\Database\DatabaseConnection;
 use openvk\Web\Util\Shell\Exceptions\UnknownCommandException;
 use openvk\Web\Util\Shell\Shell;
+use openvk\Web\Models\Repositories\Audios;
 
 /**
  * @method setName(string)
@@ -413,14 +414,16 @@ class Audio extends Media
         $obj->keys       = false;
         $obj->genre_id   = $obj->genre = self::vkGenres[$this->getGenre() ?? ""] ?? 18; # return Other if no match
         $obj->genre_str  = $this->getGenre();
-        $obj->owner_id   = $this->getOwner()->getId();
-        if ($this->getOwner() instanceof Club) {
-            $obj->owner_id *= -1;
-        }
+        $obj->owner_id   = $this->getOwner()->getRealId();
 
         $obj->lyrics = null;
         if (!is_null($this->getLyrics())) {
             $obj->lyrics = $this->getId();
+        }
+
+        $album = $this->getAlbum();
+        if ($album) {
+            $obj->album = $album->toVkApiStruct($user);
         }
 
         $obj->added      = $user && $this->isInLibraryOf($user);
@@ -440,6 +443,27 @@ class Audio extends Media
         }
 
         return $obj;
+    }
+
+    function setAlbum(Playlist $album): void 
+    {
+        $this->stateChanges("playlist_id", $album->getId());
+    }
+
+    function getAlbum(): ?Playlist
+    {
+        $playlist_id = $this->getRecord()->playlist_id;
+        if (!$playlist_id) {
+            return null;
+        }
+
+        $album = (new Audios())->getPlaylist($playlist_id);
+
+        if (!$album || $album->isDeleted()) {
+            return null;
+        }
+
+        return $album;
     }
 
     public function setOwner(int $oid): void

--- a/Web/Models/Entities/Playlist.php
+++ b/Web/Models/Entities/Playlist.php
@@ -172,14 +172,10 @@ class Playlist extends MediaCollection
 
     public function toVkApiStruct(?User $user = null): object
     {
-        $oid = $this->getOwner()->getId();
-        if ($this->getOwner() instanceof Club) {
-            $oid *= -1;
-        }
-
-        return (object) [
+        $cover = $this->getCoverPhoto();
+        $obj = (object) [
             "id"          => $this->getId(),
-            "owner_id"    => $oid,
+            "owner_id"    => $this->getOwner()->getRealId(),
             "title"       => $this->getName(),
             "description" => $this->getDescription(),
             "size"        => $this->size(),
@@ -193,6 +189,24 @@ class Playlist extends MediaCollection
             "cover_url"   => $this->getCoverURL(),
             "searchable"  => !$this->isUnlisted(),
         ];
+
+        if ($cover) {
+            $dimensions = $cover->getDimensions();
+
+            $obj->thumb = (object) [
+                "width" => $dimensions[0],
+                "height" => $dimensions[1],
+                "photo_34" => $cover->getURLBySizeId("miniscule"),
+                "photo_68" => $cover->getURLBySizeId("tiny"),
+                "photo_135" => $cover->getURLBySizeId("xsmall"),
+                "photo_270" => $cover->getURLBySizeId("small"),
+                "photo_300" => $cover->getURLBySizeId("medium"),
+                "photo_600" => $cover->getURLBySizeId("normal"),
+                "photo_1200" => $cover->getURLBySizeId("original")
+            ];
+        }
+
+        return $obj;
     }
 
     public function setLength(): void

--- a/Web/Models/Entities/Playlist.php
+++ b/Web/Models/Entities/Playlist.php
@@ -202,7 +202,7 @@ class Playlist extends MediaCollection
                 "photo_270" => $cover->getURLBySizeId("small"),
                 "photo_300" => $cover->getURLBySizeId("medium"),
                 "photo_600" => $cover->getURLBySizeId("normal"),
-                "photo_1200" => $cover->getURLBySizeId("original")
+                "photo_1200" => $cover->getURLBySizeId("original"),
             ];
         }
 

--- a/Web/Presenters/AdminPresenter.php
+++ b/Web/Presenters/AdminPresenter.php
@@ -821,7 +821,7 @@ final class AdminPresenter extends OpenVKPresenter
             $audio->setWithdrawn(!empty($this->postParam("withdrawn")));
 
             if (!empty($this->postParam("playlist_id"))) {
-                $audio->setAlbumId((int)$this->postParam("playlist_id"));
+                $audio->setAlbumId((int) $this->postParam("playlist_id"));
             }
 
             $audio->save();

--- a/Web/Presenters/AdminPresenter.php
+++ b/Web/Presenters/AdminPresenter.php
@@ -819,6 +819,11 @@ final class AdminPresenter extends OpenVKPresenter
             $audio->setExplicit(!empty($this->postParam("explicit")));
             $audio->setDeleted(!empty($this->postParam("deleted")));
             $audio->setWithdrawn(!empty($this->postParam("withdrawn")));
+
+            if (!empty($this->postParam("playlist_id"))) {
+                $audio->setAlbumId((int)$this->postParam("playlist_id"));
+            }
+
             $audio->save();
         }
     }

--- a/Web/Presenters/AudioPresenter.php
+++ b/Web/Presenters/AudioPresenter.php
@@ -274,6 +274,10 @@ final class AudioPresenter extends OpenVKPresenter
             $this->flashFail("err", tr("error"), tr("ffmpeg_not_installed"), null, $isAjax);
         }
 
+        if ($playlist) {
+            $audio->setAlbum($playlist);
+        }
+
         $audio->save();
 
         if ($playlist) {
@@ -860,7 +864,6 @@ final class AudioPresenter extends OpenVKPresenter
 
         $pagesCount = ceil($audiosCount / $perPage);
 
-        # костылёк для получения плееров в пикере аудиозаписей
         if ((int) ($this->postParam("returnPlayers")) === 1) {
             $this->template->audios = $audios;
             $this->template->page = $page;
@@ -873,21 +876,18 @@ final class AudioPresenter extends OpenVKPresenter
         $audiosArr = [];
 
         foreach ($audios as $audio) {
-            $output_array = [];
-            $output_array['id'] = $audio->getId();
-            $output_array['name'] = $audio->getTitle();
-            $output_array['performer'] = $audio->getPerformer();
+            $obj = $audio->toVkApiStruct($this->user->identity);
+            $obj->name = $audio->getTitle();
+            $obj->performer = $audio->getPerformer();
+            $obj->length = $audio->getLength();
+            $obj->available = $audio->isAvailable();
 
             if (!$audio->isWithdrawn()) {
-                $output_array['keys'] = $audio->getKeys();
-                $output_array['url'] = $audio->getUrl();
+                $obj->keys = $audio->getKeys();
+                $obj->url = $audio->getUrl();
             }
 
-            $output_array['length'] = $audio->getLength();
-            $output_array['available'] = $audio->isAvailable();
-            $output_array['withdrawn'] = $audio->isWithdrawn();
-
-            $audiosArr[] = $output_array;
+            $audiosArr[] = $obj;
         }
 
         $resultArr = [

--- a/Web/Presenters/templates/Admin/EditMusic.latte
+++ b/Web/Presenters/templates/Admin/EditMusic.latte
@@ -58,6 +58,10 @@
                 <input class="text medium-field" type="number" id="owner_id" name="owner" value="{$owner}" />
             </div>
             <div class="field-group">
+                <label for="owner">{_playlist}</label>
+                <input class="text medium-field" type="number" id="playlist_id" name="playlist_id" value="{$audio->getAlbumId()}" />
+            </div>
+            <div class="field-group">
                 <label for="explicit">Explicit</label>
                 <input class="toggle-large" type="checkbox" id="explicit" name="explicit" value="1" {if $audio->isExplicit()} checked {/if} />
             </div>

--- a/Web/Presenters/templates/Audio/bigplayer.latte
+++ b/Web/Presenters/templates/Audio/bigplayer.latte
@@ -57,5 +57,9 @@
         <div class="absoluteButtons">
             <div id="summarySwitchButton">-</div>
         </div>
+
+        <div class="absoluteButtons2">
+            <div id="playlistToggleButton">playlist</div>
+        </div>
     </div>
 </div>

--- a/Web/Presenters/templates/Audio/bigplayer.latte
+++ b/Web/Presenters/templates/Audio/bigplayer.latte
@@ -57,9 +57,12 @@
         <div class="absoluteButtons">
             <div id="summarySwitchButton">-</div>
         </div>
+    </div>
 
-        <div class="absoluteButtons2">
-            <div id="playlistToggleButton">playlist</div>
-        </div>
+    <div id="album_info">
+        <a href="#">
+            <img>
+            <span id="album_embed_name">...</span>
+        </a>
     </div>
 </div>

--- a/Web/static/css/audios.css
+++ b/Web/static/css/audios.css
@@ -58,8 +58,16 @@
     right: 0;
 }
 
-.bigPlayer .bigPlayerWrapper .absoluteButtons > div {
-    width: 8px;
+.bigPlayer .bigPlayerWrapper .absoluteButtons2 {
+    display: none;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+}
+
+.bigPlayer .bigPlayerWrapper .absoluteButtons > div,
+.bigPlayer .bigPlayerWrapper .absoluteButtons2 > div {
+    min-width: 8px;
     height: 8px;
     font-size: 9px;
 
@@ -67,9 +75,7 @@
     align-items: center;
     justify-content: center;
     background: #ebebeb;
-    border: 1px solid #c3c3c3;
-    border-bottom: unset;
-    border-right: unset;
+    outline: 1px solid #c3c3c3;
     color: #c3c3c3;
     cursor: pointer;
     user-select: none;
@@ -1103,7 +1109,7 @@
 
 #ajax_audio_player #aj_player_tracks {
     width: fit-content;
-    display: flex;
+    display: none;
     flex-direction: column;
 
     background: rgba(44, 44, 44, 0.79);
@@ -1112,6 +1118,10 @@
     margin-top: 2px;
     margin-left: 2px;
     border-radius: 0px 0px 2px 2px;
+}
+
+#ajax_audio_player:hover #aj_player_tracks {
+    display: flex;
 }
 
 #ajax_audio_player #aj_player_tracks .aj_track {

--- a/Web/static/css/audios.css
+++ b/Web/static/css/audios.css
@@ -674,13 +674,14 @@
 
 .playlistListView {
     display: flex;
-    padding: 7px;
-    gap: 9px;
+    padding: 12px;
+    gap: 13px;
     cursor: pointer;
+    border-radius: 2px;
 }
 
 .playlistListView:hover, .playlistListView .playlistCover {
-    background: #ebebeb;
+    background: var(--common-hover);
 }
 
 .playlistListView .playlistCover img {
@@ -706,6 +707,7 @@
 
 .playlistListView .playlistInfo .playlistMeta, .playlistListView .playlistInfo .playlistMeta span {
     color: #676767;
+    font-size: 10px;
 }
 
 /* other */
@@ -857,11 +859,11 @@
 }
 
 .friendsAudiosList .elem img {
-    width: 30px;
+    width: 26px;
     border-radius: 2px;
     object-fit: cover;
-    height: 31px;
-    min-width: 30px;
+    height: 26px;
+    min-width: 26px;
 }
 
 .friendsAudiosList .elem .additionalInfo {
@@ -877,6 +879,7 @@
 
 .friendsAudiosList .elem .additionalInfo .name {
     color: #2B587A;
+    font-size: 10px;
 }
 
 .friendsAudiosList #used .elem .additionalInfo .name {
@@ -888,7 +891,7 @@
     overflow: hidden;
     white-space: nowrap;
     color: #878A8F;
-    font-size: 11px;
+    font-size: 10px;
 }
 
 .friendsAudiosList #used .elem .additionalInfo .desc {

--- a/Web/static/css/audios.css
+++ b/Web/static/css/audios.css
@@ -25,7 +25,7 @@
 /* Main music player */
 
 .bigPlayer {
-    background-color: rgb(240, 241, 242);
+    background-color: var(--common-2);
     margin-left: -10px;
     margin-top: -10px;
     width: 102.8%;
@@ -58,15 +58,46 @@
     right: 0;
 }
 
-.bigPlayer .bigPlayerWrapper .absoluteButtons2 {
+.bigPlayer #album_info {
     display: none;
     position: absolute;
-    bottom: 0;
+    top: 46px;
     left: 0;
+    width: 70%;
+    background: var(--common-2);
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--brand);
+    box-shadow: 0px 5px 9px 0px #2b2b2b33;
 }
 
-.bigPlayer .bigPlayerWrapper .absoluteButtons > div,
-.bigPlayer .bigPlayerWrapper .absoluteButtons2 > div {
+.bigPlayer.album_shown #album_info {
+    display: block;
+    font-size: 10px;
+}
+
+.bigPlayer.album_shown #album_info a {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+}
+
+.bigPlayer.album_shown #album_info a, 
+.bigPlayer.album_shown #album_info span {
+    height: 8px;
+    font-size: 10px;
+}
+
+.bigPlayer.album_shown #album_info a span {
+    font-size: 10px;
+    font-weight: bold;
+}
+
+.bigPlayer.album_shown #album_info img {
+    width: 22px;
+    border-radius: 1px;
+}
+
+.bigPlayer .bigPlayerWrapper .absoluteButtons > div {
     min-width: 8px;
     height: 8px;
     font-size: 9px;

--- a/Web/static/css/main.css
+++ b/Web/static/css/main.css
@@ -1,3 +1,7 @@
+:root {
+    --common-hover: #f5f4f4;
+}
+
 html {
     overflow-y: scroll;
 }
@@ -3937,11 +3941,15 @@ hr {
     margin: 0px;
 }
 
+.media-page-wrapper-description {
+    padding: 5px 30px;
+}
+
 .media-page-wrapper-description .upload_time {
     color: gray;
     display: inline-flex;
     align-items: center;
-    height: 16px;
+    font-size: 10px;
 }
 
 .media-page-author-block {

--- a/Web/static/css/main.css
+++ b/Web/static/css/main.css
@@ -4244,7 +4244,7 @@ hr {
     position: absolute;
     bottom: 0px;
     background: rgba(1, 1, 1, 0.7);
-    padding: 6px 6px;
+    padding: 3px 6px;
     width: calc(100% - 12px);
 
     display: grid;
@@ -4262,6 +4262,7 @@ hr {
 
 .docGalleryItem .doc_bottom_panel span {
     color: white;
+    font-size: 10px;
 }
 
 .docGalleryItem .doc_bottom_panel .doc_bottom_panel_size {
@@ -4274,7 +4275,7 @@ hr {
     top: 5px;
     right: 5px;
     background: rgba(1, 1, 1, 0.7);
-    padding: 6px 6px;
+    padding: 3px 3px;
 
     display: flex;
     gap: 5px;

--- a/Web/static/css/main.css
+++ b/Web/static/css/main.css
@@ -1,5 +1,7 @@
 :root {
     --common-hover: #f5f4f4;
+    --common-2: #f0f1f2;
+    --brand: #606060;
 }
 
 html {

--- a/Web/static/js/al_music.js
+++ b/Web/static/js/al_music.js
@@ -47,12 +47,52 @@ class AudioTrack {
         this.item = item
     }
 
+    getTitle() {
+        return this.item.name
+    }
+
+    getPerformer() {
+        return this.item.performer
+    }
+
+    getPerformers() {
+        return this.item.performer.split(',')
+    }
+
     getName() {
         return `${this.item.performer} — ${this.item.name}`
     }
 
     getId() {
         return this.item.id
+    }
+
+    getPlaylistCover() {
+        if (this.item.album) {
+            return this.item.album.thumb.photo_270
+        }
+
+        return "/assets/packages/static/openvk/img/song.jpg"
+    }
+
+    getPlaylistName() {
+        if (this.item.album) {
+            return this.item.album.title
+        }
+
+        return 'ovk audios'
+    }
+
+    getPlaylistURL() {
+        if (this.item.album) {
+            return '/playlist'+this.item.album.owner_id + '_' + this.item.album.id
+        }
+
+        return '#'
+    }
+
+    hasPlaylist() {
+        return this.item.album != null
     }
 }
 
@@ -601,7 +641,7 @@ window.player = new class {
     }
 
     __updateFace() {
-        const _c = this.currentTrack
+        const _c = new AudioTrack(this.currentTrack)
         const prev_button = this.uiPlayer.find('.nextButton')
         const next_button = this.uiPlayer.find('.backButton')
 
@@ -651,9 +691,9 @@ window.player = new class {
         }
 
         if(_c) {
-            this.uiPlayer.find('.trackInfo .trackName span').html(escapeHtml(_c.name))
+            this.uiPlayer.find('.trackInfo .trackName span').html(escapeHtml(_c.getName()))
             this.uiPlayer.find('.trackInfo .trackPerformers').html('')
-            const performers = _c.performer.split(', ')
+            const performers = _c.getPerformers()
             const lastPerformer = performers[performers.length - 1]
             performers.forEach(performer => {
                 this.uiPlayer.find('.trackInfo .trackPerformers').append(
@@ -664,10 +704,21 @@ window.player = new class {
             this.uiPlayer.find('.trackInfo .trackPerformers').html(`<a>${tr('track_unknown')}</a>`)
         }
 
+        if (u('.bigPlayer #album_info').length > 0) {
+            if (_c.hasPlaylist() && u('.playlistInfo').length == 0) {
+                u('.bigPlayer').addClass('album_shown')
+                u('.bigPlayer #album_info img').attr('src', _c.getPlaylistCover())
+                u('.bigPlayer #album_info #album_embed_name').html(escapeHtml(_c.getPlaylistName()))
+                u('.bigPlayer #album_info a').attr('href', _c.getPlaylistURL())
+            } else {
+                u('.bigPlayer').removeClass('album_shown')
+            }
+        }
+
         if(this.ajaxPlayer.length > 0) {
             if(_c) {
-                this.ajaxPlayer.find('#aj_player_track_title b').html(escapeHtml(_c.performer))
-                this.ajaxPlayer.find('#aj_player_track_title span').html(escapeHtml(_c.name))
+                this.ajaxPlayer.find('#aj_player_track_title b').html(escapeHtml(_c.getPerformer()))
+                this.ajaxPlayer.find('#aj_player_track_title span').html(escapeHtml(_c.getName()))
             }
         }
 
@@ -690,12 +741,13 @@ window.player = new class {
     
     __updateMediaSession() {
         const album = document.querySelector(".playlistBlock")
-        const cur = this.currentTrack
+        const cur = new AudioTrack(this.currentTrack)
+
         navigator.mediaSession.metadata = new MediaMetadata({
-            title: escapeHtml(cur.name),
-            artist: escapeHtml(cur.performer),
-            album: album == null ? "OpenVK Audios" : escapeHtml(album.querySelector(".playlistInfo h4").innerHTML),
-            artwork: [{ src: album == null ? "/assets/packages/static/openvk/img/song.jpg" : album.querySelector(".playlistCover img").src }],
+            title: escapeHtml(cur.getName()),
+            artist: escapeHtml(cur.getPerformer()),
+            album: cur.getPlaylistName(),
+            artwork: [{ src: cur.getPlaylistCover()}],
         })
     }
 

--- a/Web/static/js/al_music.js
+++ b/Web/static/js/al_music.js
@@ -708,7 +708,7 @@ window.player = new class {
             if (_c.hasPlaylist() && u('.playlistInfo').length == 0) {
                 u('.bigPlayer').addClass('album_shown')
                 u('.bigPlayer #album_info img').attr('src', _c.getPlaylistCover())
-                u('.bigPlayer #album_info #album_embed_name').html(escapeHtml(_c.getPlaylistName()))
+                u('.bigPlayer #album_info #album_embed_name').html(escapeHtml(ovk_proc_strtr(_c.getPlaylistName(), 60)))
                 u('.bigPlayer #album_info a').attr('href', _c.getPlaylistURL())
             } else {
                 u('.bigPlayer').removeClass('album_shown')

--- a/Web/static/js/al_music.js
+++ b/Web/static/js/al_music.js
@@ -238,7 +238,7 @@ window.player = new class {
                 form_data.append('context_entity', this.context.object.entity_id)
                 break
             case 'classic_search_context':
-                // tidi riwriti
+                // todo rewrite
                 form_data.append('context', this.context.object.name)
                 form_data.append('context_entity', JSON.stringify({
                     'order': this.context.object.order,

--- a/Web/static/js/al_music.js
+++ b/Web/static/js/al_music.js
@@ -69,7 +69,7 @@ class AudioTrack {
 
     getPlaylistCover() {
         if (this.item.album) {
-            return this.item.album.thumb.photo_270
+            return this.item.album.cover_url
         }
 
         return "/assets/packages/static/openvk/img/song.jpg"

--- a/install/sqls/00060-playlist-link.sql
+++ b/install/sqls/00060-playlist-link.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `audios` ADD `playlist_id` BIGINT(20) UNSIGNED NULL DEFAULT NULL AFTER `processed`;


### PR DESCRIPTION
добавляет привязку плейлиста (альбома) к аудио если идёт загрузка в плейлист. это то что я забыл два года назад добавить. в апи это ключ album.поскольку плеер вк 2012 не рассчитан на показ превью, на латте версии сайта плейлист выводится под кнопкой играть, и блок с этим закрывает первую аудиозапись в списке что впрочем терпимо. возникает вопрос, а что же делать с песнями загруженными до этого? с ui нельзя изменить расклад, в админке можно, но там надо знать id и это неудобно.

исправлены некоторые кринджовые отступы. да дизайн овк немного одутловатый потому что текст везде одинакового размера и не сделана цветовая палитра из var()ов