### PR TITLE
fix(notifications): Correct comment URL in topic-related notifications

### DIFF
--- a/Web/Models/Entities/Comment.php
+++ b/Web/Models/Entities/Comment.php
@@ -108,7 +108,7 @@ class Comment extends Post
 
     public function getURL(): string
     {
-        return "/wall" . $this->getTarget()->getPrettyId() . "#_comment" . $this->getId();
+        return $this->getTargetURL() . "#_comment" . $this->getId();
     }
 
     public function canBeViewedBy(?User $user = null): bool


### PR DESCRIPTION
Ранее, когда пользователь ставил лайк комментарию в топиках, сгенерированная ссылка на уведомление ошибочно указывала на сообщение на стене (например, https://openvk.org/wall5374_2#_comment179780) вместо самой темы (например, https://openvk.org/topic5374_2#_comment179780).