### PR TITLE
fix(api): Include wall owner in extended wall responses

### DIFF
--- a/VKAPI/Handlers/Wall.php
+++ b/VKAPI/Handlers/Wall.php
@@ -239,6 +239,13 @@ final class Wall extends VKAPIRequestHandler
                 $groups[]   = $from_id * -1;
             }
 
+            $owner_id = $post->getTargetWall();
+            if($owner_id > 0){
+                $profiles[] = $owner_id;
+            } else {
+                $groups = $owner_id * -1;
+            }
+
             if ($post->isSigned()) {
                 $profiles[] = $post->getOwner(false)->getId();
             }
@@ -466,6 +473,13 @@ final class Wall extends VKAPIRequestHandler
                     $profiles[] = $from_id;
                 } else {
                     $groups[]   = $from_id * -1;
+                }
+
+                $owner_id = $post->getTargetWall();
+                if($owner_id > 0){
+                    $profiles[] = $owner_id;
+                } else {
+                    $groups = $owner_id * -1;
                 }
 
                 if ($post->isSigned()) {

--- a/VKAPI/Handlers/Wall.php
+++ b/VKAPI/Handlers/Wall.php
@@ -240,10 +240,10 @@ final class Wall extends VKAPIRequestHandler
             }
 
             $owner_id = $post->getTargetWall();
-            if($owner_id > 0){
+            if ($owner_id > 0) {
                 $profiles[] = $owner_id;
             } else {
-                $groups = $owner_id * -1;
+                $groups[] = $owner_id * -1;
             }
 
             if ($post->isSigned()) {
@@ -476,10 +476,10 @@ final class Wall extends VKAPIRequestHandler
                 }
 
                 $owner_id = $post->getTargetWall();
-                if($owner_id > 0){
+                if ($owner_id > 0) {
                     $profiles[] = $owner_id;
                 } else {
-                    $groups = $owner_id * -1;
+                    $groups[] = $owner_id * -1;
                 }
 
                 if ($post->isSigned()) {


### PR DESCRIPTION
Фикс #1551. Теперь с параметром extended=1 ответ включает профиль пользователя, на чьей стене оставлен пост