### PR TITLE
remove style that hides main template in doc preview

### DIFF
--- a/Web/Presenters/templates/Documents/Page.latte
+++ b/Web/Presenters/templates/Documents/Page.latte
@@ -9,17 +9,6 @@
 {/block}
 
 {block content}
-    <style>
-        .sidebar, .page_header, .page_footer {
-            opacity: 0;
-            pointer-events: none;
-        }
-
-        .page_body {
-            margin-top: -45px;
-        }
-    </style>
-
     <div class='media-page-wrapper photo-page-wrapper'>
         <div class='photo-page-wrapper-photo'>
             {if $doc->isGif()}


### PR DESCRIPTION
почему-то в темплейте документов был весёлый стиль, который скрывал весь основной интерфейс
этот коммит ликвидирует его
<img width="397" height="199" alt="изображение" src="https://github.com/user-attachments/assets/8eeb97ca-1306-42f9-945d-f255a0553465" />

до:
<img width="1280" height="643" alt="изображение" src="https://github.com/user-attachments/assets/8ab9105e-1393-4e92-977c-34cac1a6ebeb" />

после:
<img width="1280" height="675" alt="изображение" src="https://github.com/user-attachments/assets/c846c6ba-60a2-42b8-9d81-f3196ef0c9fd" />

