### PR TITLE
fix(api): use filtered attachments in wall.repost

### DIFF
--- a/VKAPI/Handlers/Wall.php
+++ b/VKAPI/Handlers/Wall.php
@@ -824,7 +824,7 @@ final class Wall extends VKAPIRequestHandler
 
         $nPost->attach($repost_entity);
 
-        foreach ($parsed_attachments as $attachment) {
+        foreach ($final_attachments as $attachment) {
             $nPost->attach($attachment);
         }
 


### PR DESCRIPTION
исправляет то, что при создании репоста игнорировалась фильтрация вложений по правам доступа и статусу удаления. можно было крч с помощью репостов постить например чьи-то фотки с закрытой страницы