### PR TITLE
fix(Web): ensure current album is selected in audio edit modal

### DIFF
--- a/Web/static/js/al_music.js
+++ b/Web/static/js/al_music.js
@@ -1715,7 +1715,7 @@ u(document).on("click", ".musicIcon.edit-icon", (e) => {
         const res = await window.OVKAPI.call('audio.getAlbums', {'count': 100, 'owner_id': owner_id})
         res.items.forEach(album => {
             album_select.insertAdjacentHTML("beforeend", `
-                <option value="${album.id}" ${album.id == album_id ? "selected" : ""}>${escapeHtml(album.title)}</option>
+                <option value="${album.id}" ${String(album.id) === String(album_id) ? "selected" : ""}>${escapeHtml(album.title)}</option>
             `)
         })
     })()


### PR DESCRIPTION
~~я считаю, что надо бить ногами каждого, кто тестирует только в одном браузере (ну т.е. меня).~~ исправил отображение текущего альбома в окне редактирования трека в браузере Firefox