### PR TITLE
chore(user): disable subscriptions removad on ban by default

### DIFF
--- a/Web/Models/Entities/User.php
+++ b/Web/Models/Entities/User.php
@@ -1077,7 +1077,7 @@ class User extends RowModel
         ]);
     }
 
-    public function ban(string $reason, bool $deleteSubscriptions = true, $unban_time = null, ?int $initiator = null): void
+    public function ban(string $reason, bool $deleteSubscriptions = false, $unban_time = null, ?int $initiator = null): void
     {
         if ($deleteSubscriptions) {
             $subs = DatabaseConnection::i()->getContext()->table("subscriptions");


### PR DESCRIPTION
Отключает по умолчанию удаление всех друзей и подписчиков и отписку от всех групп при блокировке пользователя. 
Такая мера была введена ещё в 2019-2020, так как у юзера не было возможности удалить из друзей пользователя, кроме как со страницы пользователя. Эта мера больше не нужна (юзер может удалить друга из соответствующей вкладки), и скорее больше портит впечатления об OpenVK