### PR TITLE
feat(away): redirect from instance's mirrors, don't go through away.php if it's the same domain as instance

### DIFF
--- a/Web/Models/Entities/Traits/TRichText.php
+++ b/Web/Models/Entities/Traits/TRichText.php
@@ -46,8 +46,7 @@ trait TRichText
                     $href = rawurlencode($matches[1]);
                     $href = str_replace("%26amp%3B", "%26", $href);
                     $href = 'away.php?to=' . $href;
-                }
-                else {
+                } else {
                     $domainNPath = explode("/", $matches[3], 2);
                     $href = end($domainNPath);
                 }

--- a/Web/Models/Entities/Traits/TRichText.php
+++ b/Web/Models/Entities/Traits/TRichText.php
@@ -41,24 +41,20 @@ trait TRichText
         return preg_replace_callback(
             "%(([A-z]++):\/\/(\S*?\.\S*?))([\s)\[\]{},\"\'<]|\.\s|$)%",
             (function (array $matches): string {
-                $href = rawurlencode($matches[1]);
-                $href = str_replace("%26amp%3B", "%26", $href);
+                $isSameDomain = str_replace("www.", "", explode("/", $matches[3], 2)[0]) == str_replace("www.", "", $_SERVER["SERVER_NAME"]);
+                if (!$isSameDomain) {
+                    $href = rawurlencode($matches[1]);
+                    $href = str_replace("%26amp%3B", "%26", $href);
+                    $href = 'away.php?to=' . $href;
+                }
+                else {
+                    $domainNPath = explode("/", $matches[3], 2);
+                    $href = end($domainNPath);
+                }
                 $link = $matches[3];
-                # this string breaks ampersands
-                # $link = str_replace(";", "&#59;", $link);
                 $rel  = $this->isAd() ? "sponsored" : "ugc";
 
-                /*$server_domain = str_replace(':' . $_SERVER['SERVER_PORT'], '', $_SERVER['HTTP_HOST']);
-                if(str_contains($link, $server_domain)) {
-                    $replaced_link = str_replace(':' . $_SERVER['SERVER_PORT'], '', $link);
-                    $replaced_link = str_replace($server_domain, '', $replaced_link);
-
-                    return "<a href='$replaced_link' rel='$rel'>$link</a>" . htmlentities($matches[4]);
-                }
-
-                $link = htmlentities(urldecode($link));*/
-
-                return "<a href='/away.php?to=$href' rel='$rel' target='_blank'>$link</a>" . htmlentities($matches[4]);
+                return "<a href='/$href' rel='$rel' target='_blank'>$link</a>" . htmlentities($matches[4]);
             }),
             $text
         );

--- a/Web/Presenters/AwayPresenter.php
+++ b/Web/Presenters/AwayPresenter.php
@@ -11,16 +11,27 @@ final class AwayPresenter extends OpenVKPresenter
 {
     public function renderAway(): void
     {
-        $checkBanEntries = (new BannedLinks())->check($this->queryParam("to"));
+        $redirTo = $this->queryParam("to");
         if (OPENVK_ROOT_CONF["openvk"]["preferences"]["susLinks"]["warnings"]) {
+            $checkBanEntries = (new BannedLinks())->check($redirTo);
             if (sizeof($checkBanEntries) > 0) {
                 $this->pass("openvk!Away->view", $checkBanEntries[0]);
             }
         }
 
+        if (isset(OPENVK_ROOT_CONF["openvk"]["mirrors"])) {
+            $uri = str_replace(["https://", "http://"], "", $redirTo);
+            $domainTo = explode("/", $uri)[0];
+            $isMirror = in_array(str_replace("www.", "", $domainTo), OPENVK_ROOT_CONF["openvk"]["mirrors"]);
+            if ($isMirror) {
+                $currentDomain = $_SERVER["SERVER_NAME"];
+                $redirTo = str_replace($domainTo, $currentDomain, $redirTo);
+            }
+        }
+
         header("HTTP/1.0 302 Found");
         header("X-Robots-Tag: noindex, nofollow, noarchive");
-        header("Location: " . rawurldecode($this->queryParam("to")));
+        header("Location: " . rawurldecode($redirTo));
         exit;
     }
 

--- a/install/automated/docker/openvk.example.yml
+++ b/install/automated/docker/openvk.example.yml
@@ -4,6 +4,10 @@ openvk:
         name: "OpenVK"
         motd: "Yet another OpenVK instance"
     
+    mirrors: # list all existing and previous domains without www. Won't work with different port
+        - "ovk.localhost"
+        - "ovk.local"
+
     preferences:
         femaleGenderPriority: true
         nginxCacheTime: null

--- a/openvk-example.yml
+++ b/openvk-example.yml
@@ -4,6 +4,11 @@ openvk:
         name: "OpenVK"
         motd: "Yet another OpenVK instance"
     
+    mirrors: # list all existing and previous domains without www. Won't work with different port
+        - "ovk.localhost"
+        - "ovk.local"
+
+
     preferences:
         femaleGenderPriority: true
         nginxCacheTime: null


### PR DESCRIPTION
- **feat(links, away): add direct links while inside one domain**
  - So, if you're on `openvk.org` and click on `openvk.org`, you don't need to go through away.php
- **feat(links, away): redirect any mirror domain to current one**
  - `ovk.to` is still dead, but if any from current instance would try to open an old link, they would be redirected to a domain they are on rn
  - It does not support any port beside 80 and 443
  - To disable this feature, you need to remove openvk->mirrors from root configuration
  - Potential "mirrors" for main instance: `openvk.org`, `openvk.xyz`, `openvk.su`, `openvk.uk`, `openvk.co`, `ovk.to`




