### PR TITLE
fix(api): restore notes.delete API method

### DIFF
--- a/VKAPI/Handlers/Notes.php
+++ b/VKAPI/Handlers/Notes.php
@@ -77,6 +77,30 @@ final class Notes extends VKAPIRequestHandler
         return $comment->getId();
     }
 
+    public function delete(int $note_id)
+    {
+        $this->requireUser();
+        $this->willExecuteWriteAction();
+
+        $note = (new NotesRepo())->getNoteById($this->getUser()->getId(), $note_id);
+
+        if (!$note) {
+            $this->fail(15, "Access denied");
+        }
+
+        if ($note->isDeleted()) {
+            $this->fail(15, "Access denied");
+        }
+
+        if (!$note->canBeModifiedBy($this->getUser())) {
+            $this->fail(15, "Access denied");
+        }
+
+        $note->delete();
+
+        return 1;
+    }
+
     public function edit(string $note_id, string $title = "", string $text = "", int $privacy = 0, int $comment_privacy = 0, string $privacy_view  = "", string $privacy_comment  = "")
     {
         $this->requireUser();


### PR DESCRIPTION
Метод был удалён в коммите 5a41f3b1, вероятно ошибочно