### PR TITLE
fix(ui): ctx menu inside a post

### DIFF
--- a/Web/static/css/main.css
+++ b/Web/static/css/main.css
@@ -360,6 +360,7 @@ h1 {
 .page_content {
     display: inline-block;
     width: 610px;
+    position: relative;
 }
 
 .page_wrap {

--- a/Web/static/js/al_music.js
+++ b/Web/static/js/al_music.js
@@ -1369,10 +1369,13 @@ u(document).on('contextmenu', '.bigPlayer, .audioEmbed, #ajax_audio_player', (e)
 
     u('#ctx_menu').remove()
     const ctx_type = u(e.target).closest('.bigPlayer, #ajax_audio_player').length > 0 ? 'main_player' : 'mini_player'
-    const parent = e.target.closest('.ctx_place')
-    if(!parent) {
+    const ctxPlace = e.target.closest('.ctx_place')
+    if(!ctxPlace) {
         return
     }
+
+    const pageContent = e.target.closest('.page_content')
+    const parent = pageContent ?? ctxPlace
 
     const rect = parent.getBoundingClientRect()
     let x, y;
@@ -1380,7 +1383,11 @@ u(document).on('contextmenu', '.bigPlayer, .audioEmbed, #ajax_audio_player', (e)
     x = e.pageX - rx
     y = e.pageY - ry
 
-    if((rect.height + rect.top) + 100 > window.innerHeight) {
+    if(pageContent) {
+        if(e.clientY + 100 > window.innerHeight) {
+            y -= 100
+        }
+    } else if((rect.height + rect.top) + 100 > window.innerHeight) {
         y = ((rect.height + 120) * -1)
     }
 


### PR DESCRIPTION
контекстное меню трека не вмещалось в пост и обрезалось

было:
<img width="628" height="142" alt="Screenshot_20260704_022942" src="https://github.com/user-attachments/assets/3beb7c40-0aff-4747-a72a-87aab1f10847" />

стало:
<img width="623" height="160" alt="Screenshot_20260704_022830" src="https://github.com/user-attachments/assets/2e537ec1-907b-4247-b1c4-84b430998173" />
