### PR TITLE
fix(profiles): strip verification from permanently deleted users

### DIFF
--- a/Web/Models/Entities/User.php
+++ b/Web/Models/Entities/User.php
@@ -995,6 +995,15 @@ class User extends RowModel
 
     public function isVerified(): bool
     {
+        if ($this->isDeleted() && !$this->isDeactivated()) {
+            if ($this->getRecord()->verified) {
+                $this->setVerified(0);
+                $this->save();
+            }
+
+            return false;
+        }
+
         return (bool) $this->getRecord()->verified;
     }
 

--- a/install/sqls/00061-deleted-verification.sql
+++ b/install/sqls/00061-deleted-verification.sql
@@ -1,0 +1,1 @@
+UPDATE `profiles` SET `verified` = 0 WHERE `deleted` = 1 AND `deact_date` <= UNIX_TIMESTAMP() AND `verified` = 1;


### PR DESCRIPTION
Fixes #1653

### Проблема
Когда верифицированный пользователь удаляет страницу, галочка верификации корректно остаётся на период деактивации (7 месяцев). Но после истечения срока, когда аккаунт становится `DELETED`, галочка всё ещё отображается — это неверно.

### Решение
- `User::isVerified()` возвращает `false` для окончательно удалённых аккаунтов (`deleted = 1` и `deact_date <= now`)
- При первом обращении к такому профилю флаг `verified` сбрасывается в БД
- Миграция `00061-deleted-verification.sql` чистит уже существующие затронутые профили

### Поведение
| Состояние | Галочка |
|-----------|---------|
| Активный профиль | как было |
| Деактивирован (grace period) | **остаётся** |
| DELETED (срок истёк) | **снимается** |

После мержа на инстансах нужно выполнить `./openvkctl upgrade`.