### PR TITLE
fix(mobile.css): msg mobile style

### DIFF
--- a/Web/static/css/mobile.css
+++ b/Web/static/css/mobile.css
@@ -744,6 +744,9 @@
     .msg {
         width: 100%;
         box-sizing: border-box;
+    }
+
+    .msg:has(+ .left_small_block) {
         position: sticky;
         top: 334px;
     }

--- a/Web/static/css/mobile.css
+++ b/Web/static/css/mobile.css
@@ -744,6 +744,8 @@
     .msg {
         width: 100%;
         box-sizing: border-box;
+        position: sticky;
+        top: 334px;
     }
 
     #sudo-banner {


### PR DESCRIPTION
например после отправки подарка с мобильной версии, сообщение отображается криво
<img width="298" height="515" alt="Screenshot_20260707_021150" src="https://github.com/user-attachments/assets/92918842-b0f0-4139-957f-c9108168f413" />


т.к. там всё на абсолютах, не нашёл ничего лучше как просто сместить его вниз
<img width="363" height="681" alt="image" src="https://github.com/user-attachments/assets/fb6461ea-8343-4c5d-ba0e-444c4a2bbaf6" />
