### PR TITLE
fix(api): VKAPI patches for `execute`, `Account.getCounters`, `Wall.getComment` and `Wall.getComments`

### DIFF
--- a/VKAPI/Handlers/Account.php
+++ b/VKAPI/Handlers/Account.php
@@ -86,7 +86,7 @@ final class Account extends VKAPIRequestHandler
     public function getCounters(string $filter = ""): object
     {
         $this->requireUser();
-        
+
         $all_counters = [
             "friends"       => $this->getUser()->getRequestsCount(),
             "notifications" => $this->getUser()->getNotificationsCount(),

--- a/VKAPI/Handlers/Account.php
+++ b/VKAPI/Handlers/Account.php
@@ -90,7 +90,7 @@ final class Account extends VKAPIRequestHandler
         $all_counters = [
             "friends"       => $this->getUser()->getRequestsCount(),
             "notifications" => $this->getUser()->getNotificationsCount(),
-            "messages"      => $this->getUser()->getUnreadMessagesCount()
+            "messages"      => $this->getUser()->getUnreadMessagesCount(),
         ];
 
         if (!empty($filter)) {

--- a/VKAPI/Handlers/Account.php
+++ b/VKAPI/Handlers/Account.php
@@ -90,7 +90,7 @@ final class Account extends VKAPIRequestHandler
         $all_counters = [
             "friends"       => $this->getUser()->getRequestsCount(),
             "notifications" => $this->getUser()->getNotificationsCount(),
-            "messages"      => $this->getUser()->getUnreadMessagesCount(),
+            "messages"      => $this->getUser()->getUnreadMessagesCount()
         ];
 
         if (!empty($filter)) {

--- a/VKAPI/Handlers/Account.php
+++ b/VKAPI/Handlers/Account.php
@@ -14,23 +14,23 @@ final class Account extends VKAPIRequestHandler
         $this->requireUser();
         $user = $this->getUser();
         $return_object = (object) [
-            "first_name"       => $user->getFirstName(),
-            "photo_200"        => $user->getAvatarURL("normal"),
-            "nickname"         => $user->getPseudo(),
-            "is_service_account" => false,
-            "id"               => $user->getId(),
-            "is_verified"      => $user->isVerified(),
+            "first_name"          => $user->getFirstName(),
+            "photo_200"           => $user->getAvatarURL("normal"),
+            "nickname"            => $user->getPseudo(),
+            "is_service_account"  => false,
+            "id"                  => $user->getId(),
+            "is_verified"         => $user->isVerified(),
             "verification_status" => $user->isVerified() ? 'verified' : 'unverified',
-            "last_name"        => $user->getLastName(),
-            "home_town"        => $user->getHometown(),
-            "status"           => $user->getStatus(),
-            "bdate"            => is_null($user->getBirthday()) ? '01.01.1970' : $user->getBirthday()->format('%e.%m.%Y'),
-            "bdate_visibility" => $user->getBirthdayPrivacy(),
-            "phone"            => "+420 ** *** 228",                       # TODO
-            "relation"         => $user->getMaritalStatus(),
-            "screen_name"      => $user->getShortCode(),
-            "sex"              => $user->isFemale() ? 1 : 2,
-            #"email"            => $user->getEmail(),
+            "last_name"           => $user->getLastName(),
+            "home_town"           => $user->getHometown(),
+            "status"              => $user->getStatus(),
+            "bdate"               => is_null($user->getBirthday()) ? '01.01.1970' : $user->getBirthday()->format('%e.%m.%Y'),
+            "bdate_visibility"    => $user->getBirthdayPrivacy(),
+            "phone"               => "+420 ** *** 228",                       # TODO
+            "relation"            => $user->getMaritalStatus(),
+            "screen_name"         => $user->getShortCode(),
+            "sex"                 => $user->isFemale() ? 1 : 2,
+            #"email"              => $user->getEmail(),
         ];
 
         $audio_status = $user->getCurrentAudioStatus();
@@ -86,12 +86,11 @@ final class Account extends VKAPIRequestHandler
     public function getCounters(string $filter = ""): object
     {
         $this->requireUser();
-
+        
         $all_counters = [
-            "friends"       => $this->getUser()->getFollowersCount(),
+            "friends"       => $this->getUser()->getRequestsCount(),
             "notifications" => $this->getUser()->getNotificationsCount(),
             "messages"      => $this->getUser()->getUnreadMessagesCount(),
-            "requests"      => $this->getUser()->getRequestsCount(),
         ];
 
         if (!empty($filter)) {

--- a/VKAPI/Handlers/Execute.php
+++ b/VKAPI/Handlers/Execute.php
@@ -128,7 +128,8 @@ final class Execute extends VKAPIRequestHandler
         return $newsfeed->get($fields, $start_from, $start_time, $end_time, $offset, $count, $extended, 0);
     }
 
-    public function getProfiles(string $user_ids = "0", string $fields = "", string $relation_case = "def", int $offset = 0, int $count = 100) {
+    public function getProfiles(string $user_ids = "0", string $fields = "", string $relation_case = "def", int $offset = 0, int $count = 100) 
+    {
         // alias of users.get, used in VK 3.10 Android app
         $users = $this->createHandler(Users::class);
         return $users->get($user_ids, $fields, $offset, $count);

--- a/VKAPI/Handlers/Execute.php
+++ b/VKAPI/Handlers/Execute.php
@@ -127,4 +127,9 @@ final class Execute extends VKAPIRequestHandler
         $newsfeed = $this->createHandler(Newsfeed::class);
         return $newsfeed->get($fields, $start_from, $start_time, $end_time, $offset, $count, $extended, 0);
     }
+
+    public function getProfiles(string $user_ids = "0", string $fields = "", string $relation_case = "def", int $offset = 0, int $count = 100) {
+        $users = $this->createHandler(Users::class);
+        return $users->get($user_ids, $fields, $offset, $count);
+    }
 }

--- a/VKAPI/Handlers/Execute.php
+++ b/VKAPI/Handlers/Execute.php
@@ -128,7 +128,7 @@ final class Execute extends VKAPIRequestHandler
         return $newsfeed->get($fields, $start_from, $start_time, $end_time, $offset, $count, $extended, 0);
     }
 
-    public function getProfiles(string $user_ids = "0", string $fields = "", string $relation_case = "def", int $offset = 0, int $count = 100) 
+    public function getProfiles(string $user_ids = "0", string $fields = "", string $relation_case = "def", int $offset = 0, int $count = 100)
     {
         // alias of users.get, used in VK 3.10 Android app
         $users = $this->createHandler(Users::class);

--- a/VKAPI/Handlers/Execute.php
+++ b/VKAPI/Handlers/Execute.php
@@ -129,6 +129,7 @@ final class Execute extends VKAPIRequestHandler
     }
 
     public function getProfiles(string $user_ids = "0", string $fields = "", string $relation_case = "def", int $offset = 0, int $count = 100) {
+        // alias of users.get, used in VK 3.10 Android app
         $users = $this->createHandler(Users::class);
         return $users->get($user_ids, $fields, $offset, $count);
     }

--- a/VKAPI/Handlers/Wall.php
+++ b/VKAPI/Handlers/Wall.php
@@ -930,7 +930,7 @@ final class Wall extends VKAPIRequestHandler
 
             $items[] = $item;
             if ($extended == true) {
-                if($comment->getOwner()->getId() > 0) {
+                if ($comment->getOwner()->getId() > 0) {
                     $profiles[] = $comment->getOwner()->getId();
                 } else {
                     $groups[] = $comment->getOwner()->getId() * -1;

--- a/VKAPI/Handlers/Wall.php
+++ b/VKAPI/Handlers/Wall.php
@@ -866,6 +866,7 @@ final class Wall extends VKAPIRequestHandler
 
         $items = [];
         $profiles = [];
+        $groups = [];
 
         foreach ($comments as $comment) {
             $owner = $comment->getOwner();
@@ -929,7 +930,11 @@ final class Wall extends VKAPIRequestHandler
 
             $items[] = $item;
             if ($extended == true) {
-                $profiles[] = $comment->getOwner()->getId();
+                if($comment->getOwner()->getId() > 0) {
+                    $profiles[] = $comment->getOwner()->getId();
+                } else {
+                    $groups[] = $comment->getOwner()->getId() * -1;
+                }
             }
 
             $attachments = null;
@@ -947,7 +952,9 @@ final class Wall extends VKAPIRequestHandler
 
         if ($extended == true) {
             $profiles = array_unique($profiles);
+            $groups   = array_unique($groups);
             $response['profiles'] = (!empty($profiles) ? (new Users())->get(implode(',', $profiles), $fields) : []);
+            $response['groups']   = (!empty($groups) ? (new Groups())->get(implode(',', $groups), $fields) : []);
         }
 
         return (object) $response;
@@ -968,6 +975,7 @@ final class Wall extends VKAPIRequestHandler
         }
 
         $profiles = [];
+        $groups = [];
 
         $attachments = [];
 
@@ -1035,7 +1043,9 @@ final class Wall extends VKAPIRequestHandler
 
         if ($extended == true) {
             $profiles = array_unique($profiles);
+            $groups   = array_unique($groups);
             $response['profiles'] = (!empty($profiles) ? (new Users())->get(implode(',', $profiles), $fields) : []);
+            $response['groups']   = (!empty($groups) ? (new Groups())->get(implode(',', $groups), $fields) : []);
         }
 
         return $response;


### PR DESCRIPTION
На работоспособность кода я не проверял, однако этот фикс должен помочь решить проблему с профилями в официальном клиенте ВК 3.10 на Android. Также удаляет поле `requests` в `Account.getCounters`, поскольку смысла в этом нет, так как в официальной документации VKAPI всех версий (что OpenVK, что оригинал всех версий) `friends` должен показывать количество входящих заявок в друзья, а не количество подписчиков.

А также фикс в `Wall.getComment` и `Wall.getComments` добавляет определение групп для комментариев, которые были отправлены от имени группы (группа должна иметь отрицательный ID).

Fixes #1681