### PR TITLE
fix(search): prevent 500 when searching posts

### DIFF
--- a/Web/Models/Entities/Post.php
+++ b/Web/Models/Entities/Post.php
@@ -292,11 +292,8 @@ class Post extends Postable
 
         if ($this->getTargetWall() < 0) {
             $club = (new Clubs())->get(abs($this->getTargetWall()));
-            if (!$club) {
-                return false;
-            }
 
-            return $club->canBeModifiedBy($user);
+            return $club?->canBeModifiedBy($user) ?? false;
         }
 
         return $this->getTargetWall() === $user->getId();
@@ -310,11 +307,11 @@ class Post extends Postable
 
         if ($this->getTargetWall() < 0) {
             $wallOwner = $this->getWallOwner();
-            if (!$wallOwner) {
-                return false;
-            }
-
-            if (!$wallOwner->canBeModifiedBy($user) && $wallOwner->getWallType() != 1 && $this->getSuggestionType() == 0) {
+            if (
+                !($wallOwner?->canBeModifiedBy($user) ?? false)
+                && ($wallOwner?->getWallType() ?? 0) != 1
+                && $this->getSuggestionType() == 0
+            ) {
                 return false;
             }
         }

--- a/Web/Models/Entities/Post.php
+++ b/Web/Models/Entities/Post.php
@@ -291,7 +291,12 @@ class Post extends Postable
         }
 
         if ($this->getTargetWall() < 0) {
-            return (new Clubs())->get(abs($this->getTargetWall()))->canBeModifiedBy($user);
+            $club = (new Clubs())->get(abs($this->getTargetWall()));
+            if (!$club) {
+                return false;
+            }
+
+            return $club->canBeModifiedBy($user);
         }
 
         return $this->getTargetWall() === $user->getId();
@@ -303,8 +308,15 @@ class Post extends Postable
             return false;
         }
 
-        if ($this->getTargetWall() < 0 && !$this->getWallOwner()->canBeModifiedBy($user) && $this->getWallOwner()->getWallType() != 1 && $this->getSuggestionType() == 0) {
-            return false;
+        if ($this->getTargetWall() < 0) {
+            $wallOwner = $this->getWallOwner();
+            if (!$wallOwner) {
+                return false;
+            }
+
+            if (!$wallOwner->canBeModifiedBy($user) && $wallOwner->getWallType() != 1 && $this->getSuggestionType() == 0) {
+                return false;
+            }
         }
 
         return $this->getOwnerPost() === $user->getId() || $this->canBePinnedBy($user);

--- a/Web/Models/Entities/Post.php
+++ b/Web/Models/Entities/Post.php
@@ -307,11 +307,7 @@ class Post extends Postable
 
         if ($this->getTargetWall() < 0) {
             $wallOwner = $this->getWallOwner();
-            if (
-                !($wallOwner?->canBeModifiedBy($user) ?? false)
-                && ($wallOwner?->getWallType() ?? 0) != 1
-                && $this->getSuggestionType() == 0
-            ) {
+            if (!$wallOwner?->canBeModifiedBy($user) && $wallOwner?->getWallType() != 1 && $this->getSuggestionType() == 0) {
                 return false;
             }
         }

--- a/Web/Models/Repositories/Posts.php
+++ b/Web/Models/Repositories/Posts.php
@@ -205,6 +205,28 @@ class Posts
                 case 'wall_id':
                     $result->where("wall", $paramValue);
                     break;
+                case "ignore_private":
+                    if (!$paramValue) {
+                        break;
+                    }
+
+                    # Only public walls with existing owners (search must not 500 on deleted entities)
+                    $openUsers = $this->context->table("profiles")
+                        ->select("id")
+                        ->where(["deleted" => 0, "profile_type" => 0]);
+                    $publicGroups = $this->context->table("groups")
+                        ->select("id")
+                        ->where("hide_from_global_feed", 0);
+                    $result->where(
+                        "(wall > 0 AND wall IN (?)) OR (wall < 0 AND (-wall) IN (?))",
+                        $openUsers,
+                        $publicGroups
+                    );
+                    $result->where(
+                        "owner IN (?)",
+                        $this->context->table("profiles")->select("id")->where("deleted", 0)
+                    );
+                    break;
             }
         }
 

--- a/Web/Presenters/templates/Search/Index.latte
+++ b/Web/Presenters/templates/Search/Index.latte
@@ -242,7 +242,9 @@
                                 </script>
                             {elseif $section === 'posts'}
                                 <div class='scroll_node search_content' n:foreach="$data as $dat">
-                                    {if !$dat || $dat->getWallOwner()->isHideFromGlobalFeedEnabled()}
+                                    {var $wallOwner = $dat ? $dat->getWallOwner() : null}
+                                    {var $postOwner = $dat ? $dat->getOwner() : null}
+                                    {if !$dat || !$wallOwner || !$postOwner || $wallOwner->isHideFromGlobalFeedEnabled()}
                                         {_closed_group_post}.
                                     {else}
                                         {include "../components/post.latte", post => $dat, commentSection => true, onWallOf => true}


### PR DESCRIPTION
НАСТОЯЩИЙ МАТЕРИАЛ (ИСХОДНЫЙ КОД) СОЗДАН И (ИЛИ) ОТРЕДАКТИРОВАН ПРИ УЧАСТИИ ИИ-АГЕНТА И (ИЛИ) КАСАЕТСЯ ДЕЯТЕЛЬНОСТИ ТАКОГО ИИ-АГЕНТА

Fixes #1404

Клик по «Записи» в поиске давал 500 — в выдачу лезли посты с удалённых стен/авторов, canBePinnedBy падал на null.

Фиксы:
* ignore_private в Posts::find
* null-safe canBePinnedBy / canBeDeletedBy (?->)
* проверки в шаблоне поиска