### PR TITLE
feat(audio): disabling music for certain users/test accounts

### DIFF
--- a/VKAPI/Handlers/Account.php
+++ b/VKAPI/Handlers/Account.php
@@ -30,7 +30,6 @@ final class Account extends VKAPIRequestHandler
             "relation"            => $user->getMaritalStatus(),
             "screen_name"         => $user->getShortCode(),
             "sex"                 => $user->isFemale() ? 1 : 2,
-            #"email"              => $user->getEmail(),
         ];
 
         $audio_status = $user->getCurrentAudioStatus();
@@ -57,6 +56,7 @@ final class Account extends VKAPIRequestHandler
             "lang"                          => 1,
             "no_wall_replies"               => 0,
             "own_posts_default"             => 0,
+            "music_available"               => (bool) !in_array($this->getUser()->getId(), OPENVK_ROOT_CONF["openvk"]["preferences"]["music"]["notAvailableFor"] ?? []),
         ];
     }
 

--- a/Web/Presenters/VKAPIPresenter.php
+++ b/Web/Presenters/VKAPIPresenter.php
@@ -368,6 +368,12 @@ final class VKAPIPresenter extends OpenVKPresenter
             throw new APIErrorException("Unknown method passed.", 3);
         }
 
+        // Way to bypass restrictions in App Stores. Check code comment for isMusicAvailable func
+        if (!is_null($identity) && !$this->isMusicAvailable($identity->getId()) && $object == "Audio")
+        {
+            throw new APIErrorException("Unknown method passed.", 3);
+        }
+
         $hasRss = false;
         $route  = new \ReflectionMethod($handler, $method);
         $args   = [];
@@ -711,5 +717,17 @@ final class VKAPIPresenter extends OpenVKPresenter
             default:
                 return "unknown";
         }
+    }
+
+    /*
+     * This is the way to get around some App Store copyright rules
+     * for (maybe) official and third party apps, something 
+     * Durov's team maybe did when their app was gone from App Store 
+     * in 2014. Now it's deleted via EU sanctions, but that's 
+     * another story to tell.
+     */
+    private function isMusicAvailable(int $id): bool
+    {
+        return (bool) !in_array($id, OPENVK_ROOT_CONF["openvk"]["preferences"]["music"]["notAvailableFor"] ?? []);
     }
 }

--- a/Web/Presenters/VKAPIPresenter.php
+++ b/Web/Presenters/VKAPIPresenter.php
@@ -369,8 +369,7 @@ final class VKAPIPresenter extends OpenVKPresenter
         }
 
         // Way to bypass restrictions in App Stores. Check code comment for isMusicAvailable func
-        if (!is_null($identity) && !$this->isMusicAvailable($identity->getId()) && $object == "Audio")
-        {
+        if (!is_null($identity) && !$this->isMusicAvailable($identity->getId()) && $object == "Audio") {
             throw new APIErrorException("Unknown method passed.", 3);
         }
 
@@ -721,9 +720,9 @@ final class VKAPIPresenter extends OpenVKPresenter
 
     /*
      * This is the way to get around some App Store copyright rules
-     * for (maybe) official and third party apps, something 
-     * Durov's team maybe did when their app was gone from App Store 
-     * in 2014. Now it's deleted via EU sanctions, but that's 
+     * for (maybe) official and third party apps, something
+     * Durov's team maybe did when their app was gone from App Store
+     * in 2014. Now it's deleted via EU sanctions, but that's
      * another story to tell.
      */
     private function isMusicAvailable(int $id): bool

--- a/openvk-example.yml
+++ b/openvk-example.yml
@@ -78,6 +78,7 @@ openvk:
             strict: false
         music:
             exposeOriginalURLs: true
+            notAvailableFor: []
         newsfeed:
             ignoredSourcesLimit: 50
         notes:


### PR DESCRIPTION
Для приложений, которые хотят выпускаться в официальный App Store. Разработчик может обратиться к нам, чтобы мы внесли созданные им аккаунты в ЧС музыки, а тот уже передал их в магазин

Если юзер в ЧС, то:
* В Account.getInfo "music_available" ставится на false (чтобы можно визуально было убрать музыку)
* Методы музыки недоступны, как несуществующие