### PR TITLE
fix(mobile): deactivated user style

### DIFF
--- a/Web/Presenters/templates/@deactivated.latte
+++ b/Web/Presenters/templates/@deactivated.latte
@@ -11,7 +11,7 @@
     </div>
 
     <div class="left_small_block">
-        <div>
+        <div class="avatar_block">
             <img src="{$thisUser->getAvatarUrl('normal')}"
                 alt="{$thisUser->getCanonicalName()}"
                 style="width: 100%; image-rendering: -webkit-optimize-contrast;" />
@@ -19,7 +19,7 @@
     </div>
 
     <div class="right_big_block">
-        <div class="page_info">
+        <div class="page_info_main">
             <div class="accountInfo clearFix">
                 <div class="profileName">
                     <h2>{$thisUser->getFullName()}</h2>

--- a/Web/Presenters/templates/User/deactivated.latte
+++ b/Web/Presenters/templates/User/deactivated.latte
@@ -7,7 +7,7 @@
 
 {block content}
     <div class="left_small_block">
-        <div>
+        <div class="avatar_block">
             <img src="{$user->getAvatarUrl('normal')}"
                 alt="{$user->getCanonicalName()}"
                 style="width: 100%; image-rendering: -webkit-optimize-contrast;" />
@@ -15,7 +15,7 @@
     </div>
 
     <div class="right_big_block">
-        <div class="page_info">
+        <div class="page_info_main">
             <div class="accountInfo clearFix">
                 <div class="profileName">
                     <h2>{$user->getFullName()}</h2>

--- a/Web/static/css/mobile.css
+++ b/Web/static/css/mobile.css
@@ -1169,6 +1169,8 @@
 
     #deactivated_block {
         margin: 0px 10px 10px 0px !important;
+        position: sticky;
+        top: 215px;
     }
 
     .user_info_h4 {


### PR DESCRIPTION
Удалённая страница некорректно отображалась на мобильной версии
<img width="429" height="898" alt="image" src="https://github.com/user-attachments/assets/1fd2ea9a-8b99-416e-bce9-83af51b50faa" />


Стало: 
<img width="426" height="906" alt="image" src="https://github.com/user-attachments/assets/ae650981-ad9e-4264-a16d-769be7a76d11" />

Также поправил от лица владельца страницы
<img width="425" height="905" alt="image" src="https://github.com/user-attachments/assets/d93b9b40-34a2-4731-a3be-3b873b8397b0" />


<img width="428" height="894" alt="image" src="https://github.com/user-attachments/assets/880c57a1-d90b-477c-bbcf-dbbdfac0e50e" />

