### PR TITLE
fix: webm processing

### DIFF
--- a/Web/Models/Entities/Video.php
+++ b/Web/Models/Entities/Video.php
@@ -36,8 +36,9 @@ class Video extends Media
             throw new \DomainException("$filename does not contain any video streams");
         }
 
+        $streams_durations = Shell::ffprobe("-i", $filename, "-show_entries", "format=duration", "-loglevel error")->execute($error);
         $durations = [];
-        preg_match_all('%duration=([0-9\.]++)%', $streams, $durations);
+        preg_match_all('%duration=([0-9\.]++)%', $streams_durations, $durations);
         if (sizeof($durations[1]) === 0) {
             throw new \DomainException("$filename does not contain any meaningful video streams");
         }


### PR DESCRIPTION
суть ситуации: при попытке прогнать .webm файл используя -show_streams в ффпробе выводит duration=n/а ввиду того что контейнер записывает длительность дорожки в другой тег TAG:DURATION????
результатом является пустая переменная после грепа и отказ в процессинге

второй запрос выводит длительность нормально вне зависимости от типа контейнера
(потыкал .mov, .webm, .mp4 на локалке, работало)