### PR TITLE
fix(photos): preserve source page after photo deletion

### DIFF
--- a/Web/Presenters/PhotosPresenter.php
+++ b/Web/Presenters/PhotosPresenter.php
@@ -410,10 +410,34 @@ final class PhotosPresenter extends OpenVKPresenter
             $this->flashFail("err", tr("error_access_denied_short"), tr("error_access_denied"));
         }
 
-        if (!is_null($album = $photo->getAlbum())) {
+        $redirect = null;
+        $returnTo = $this->queryParam("return_to");
+
+        if (is_string($returnTo) && $returnTo !== "") {
+            $parsedReturnTo = parse_url($returnTo);
+            if ($parsedReturnTo !== false && !isset($parsedReturnTo["host"]) && str_starts_with($returnTo, "/") && !str_starts_with($returnTo, "//")) {
+                $redirect = $returnTo;
+            } elseif ($parsedReturnTo !== false && isset($parsedReturnTo["host"])) {
+                $currentHost = strtolower((string) ($_SERVER["HTTP_HOST"] ?? ""));
+                $returnHost = strtolower($parsedReturnTo["host"] . (isset($parsedReturnTo["port"]) ? ":" . $parsedReturnTo["port"] : ""));
+                if ($currentHost !== "" && $returnHost === $currentHost) {
+                    $redirect = $parsedReturnTo["path"] ?? "/";
+                    if (isset($parsedReturnTo["query"])) {
+                        $redirect .= "?" . $parsedReturnTo["query"];
+                    }
+                    if (isset($parsedReturnTo["fragment"])) {
+                        $redirect .= "#" . $parsedReturnTo["fragment"];
+                    }
+                }
+            }
+        }
+
+        if ($redirect === null && !is_null($album = $photo->getAlbum())) {
             $redirect = '/album' . $album->getPrettyId();
-        } else {
-            $redirect = "/id0";
+        }
+
+        if ($redirect === null) {
+            $redirect = $photo->getOwner()->getURL();
         }
 
         $photo->isolate();

--- a/Web/Presenters/templates/Photos/Photo.latte
+++ b/Web/Presenters/templates/Photos/Photo.latte
@@ -76,7 +76,7 @@
                     </a>
                     <div n:if="isset($thisUser) && $thisUser->getId() === $photo->getOwner()->getId()">
                         <a href="/photo{$photo->getPrettyId()}/edit" class="profile_link" style="display:block;width:96%;">{_edit}</a>
-                        <a id="_photoDelete" href="/photo{$photo->getPrettyId()}/delete" class="profile_link" style="display:block;width:96%;">{_delete}</a>
+                        <a id="_photoDelete" href="/photo{$photo->getPrettyId()}/delete{ifset $_SERVER['HTTP_REFERER']}?return_to={rawurlencode($_SERVER['HTTP_REFERER'])}{/ifset}" class="profile_link" style="display:block;width:96%;">{_delete}</a>
                     </div>
                     <a href="{$photo->getURL()}" class="profile_link" target="_blank" style="display:block;width:96%;">{_"open_original"}</a>
                     <a n:if="isset($thisUser) && $thisUser->getId() != $photo->getOwner()->getId()" class="profile_link" style="display:block;width:96%;" href="javascript:reportPhoto({$photo->getId()})">{_report}</a>


### PR DESCRIPTION
если в настройках основной страницы стояла лента, при удалении фото со страницы, отправляло на `/feed` вместо страницы юзера из-за того, что `/id0` отправляет в ленту

не знаю, является ли поведение отправки `/id0` в ленту при значении `Main page - My feed`, вместо страницы пользователя (хз, как будто должно быть в любом случае id0 = текущий юзер, не?)

im so fucking confused